### PR TITLE
Add kallisto indexing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ override.tf.json
 # Nextflow workdirs and logs
 work
 *.nextflow*
+
+workflows/rnaseq-ref-index/annotation/
+
+workflows/rnaseq-ref-index/fasta/

--- a/workflows/rnaseq-ref-index/README.md
+++ b/workflows/rnaseq-ref-index/README.md
@@ -6,13 +6,19 @@ The scripts in this directory implement a workflow for downloading and indexing 
 
 All reference files are downloaded from Ensembl for consistency, using the current version as of this writing: v100.
 Fasta files to be downloaded are listed in `fasta_ref_urls.txt` and other annotation files can be listed in `annotation_ref_urls.txt`.
-These files are then downloaded by running the bash script `get-refs.sh` which will download the selected files to a local machine, then sync to
-the following S3 location: `s3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-100`
+These files are then downloaded by running the bash script `get-refs.sh` which will download the selected files to a local machine, then sync to the following S3 location: `s3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-100`
+
+In addition, `get-refs.sh` will also combine the `cdna` and `ncrna` files into a single `txome` file to allow RNAseq mapping to all transcripts.
 
 ## Indexing
 
 Currently, only salmon indexing is implemented, without decoys.
-The workflow expects to find the reference cdna file at `s3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-100/fasta/Homo_sapiens.GRCh38.ncrna.fa.gz` and will place the salmon index directories at `s3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-100/salmon_index` with subdirectories for each type of index.
+The workflow expects to find the following reference sequence files:
+
+- **cdna** at `s3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-100/fasta/Homo_sapiens.GRCh38.cdna.all.fa.gz`
+- **txome** at `s3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-100/fasta/Homo_sapiens.GRCh38.txome.fa.gz`
+
+and will place the salmon index directories at `s3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-100/salmon_index` with subdirectories for each type of index.
 
 To run the index script locally, navigate to this directory and run
 ```

--- a/workflows/rnaseq-ref-index/build-index.nf
+++ b/workflows/rnaseq-ref-index/build-index.nf
@@ -34,6 +34,23 @@ process salmon_index{
     """
 }
 
+process kallisto_index{
+  container 'quay.io/biocontainers/kallisto:0.46.2--h4f7b962_1'
+  publishDir "${params.ref_dir}/kallisto_index" , mode: 'copy'
+  memory 32.GB
+  input:
+    tuple path(reference), val(index_base), val(kmer)
+  output:
+    path "${index_base}_k${kmer}"
+  script:
+    """
+    kallisto index \
+      -i ${index_base}_k${kmer} \
+      -k ${kmer} \
+      ${reference}
+    """
+}
+
 workflow {
   // channel of the reference files and labels
   ch_ref = Channel
@@ -45,4 +62,5 @@ workflow {
   ch_index = ch_ref.combine(ch_kmer)
 
   salmon_index(ch_index)
+  kallisto_index(ch_index)
 }

--- a/workflows/rnaseq-ref-index/build-index.nf
+++ b/workflows/rnaseq-ref-index/build-index.nf
@@ -4,7 +4,7 @@ nextflow.enable.dsl=2
 // basic parameters
 params.ref_dir = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-100'
 params.cdna = 'fasta/Homo_sapiens.GRCh38.cdna.all.fa.gz'
-params.ncrna = 'fasta/Homo_sapiens.GRCh38.ncrna.fa.gz'
+params.txome = 'fasta/Homo_sapiens.GRCh38.txome.fa.gz'
 params.kmer = [23, 31]
 
 
@@ -35,13 +35,14 @@ process salmon_index{
 }
 
 workflow {
-  // channel of the reference file(s) and a label
+  // channel of the reference files and labels
   ch_ref = Channel
-    .fromList([[params.ref_dir + "/" + params.cdna, "cdna"]])
+    .fromList([[params.ref_dir + "/" + params.cdna, "cdna"],
+               [params.ref_dir + "/" + params.txome, "txome"]])
   // possible kmer values
   ch_kmer = Channel.fromList(params.kmer)
   // create a channel with all k values for each ref
-  ch_salmon = ch_ref.combine(ch_kmer)
+  ch_index = ch_ref.combine(ch_kmer)
 
-  salmon_index(ch_salmon)
+  salmon_index(ch_index)
 }

--- a/workflows/rnaseq-ref-index/get-refs.sh
+++ b/workflows/rnaseq-ref-index/get-refs.sh
@@ -5,6 +5,11 @@ s3_base=s3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-100
 
 # Get reference fasta files and sync to S3
 wget -N -P fasta -i fasta_ref_urls.txt
+# combine cdna & ncrna fasta files
+cat fasta/Homo_sapiens.GRCh38.cdna.all.fa.gz \
+  fasta/Homo_sapiens.GRCh38.ncrna.fa.gz \
+  > fasta/Homo_sapiens.GRCh38.txome.fa.gz
+
 aws s3 sync fasta $s3_base/fasta
 
 # get annotation files & sync


### PR DESCRIPTION
This PR adds a nextflow process for indexing the same transcript files as salmon with kallisto. It may ask for more memory than is strictly needed, but it does need more than the minimum/batch default.