### PR TITLE
Add a docker image definition with R tools

### DIFF
--- a/workflows/images/scpca_r/Dockerfile
+++ b/workflows/images/scpca_r/Dockerfile
@@ -28,6 +28,7 @@ RUN install2.r --error --deps TRUE \
 # Install bioconductor packages
 RUN R -e "BiocManager::install(c( \
     'AnnotationHub', \
+    'ensembldb', \
     'scran', \
     'scater', \
     'tximport'), \


### PR DESCRIPTION
Here I am adding a Dockerfile that contains a relatively lean set of R packages for scRNA analysis. I fully expect this package to expanded as needed as we add steps to the pipeline. But I would assume those would end up in separate PRs. 
As such, this closes #13

I did end up keeping this based on an image that contains Rstudio to ease development. 