### PR TITLE
Add tx2gene and mitochondrial files

### DIFF
--- a/workflows/images/scpca_r/Dockerfile
+++ b/workflows/images/scpca_r/Dockerfile
@@ -1,0 +1,37 @@
+FROM rocker/tidyverse:4.0.2
+LABEL maintainer="ccdl@alexslemonade.org"
+
+### Install apt-getable packages to start
+#########################################
+RUN apt-get update && apt-get install -y --no-install-recommends apt-utils dialog
+
+# Add curl, bzip2 and dev libs
+RUN apt-get update -qq && apt-get -y --no-install-recommends install \
+    bzip2 \
+    curl \
+    libbz2-dev \
+    libgdal-dev \
+    liblzma-dev \
+    libreadline-dev \
+    libudunits2-dev
+
+
+#### R packages
+###############
+
+# Commonly used R packages
+RUN install2.r --error --deps TRUE \
+    optparse \
+    rprojroot
+
+##########################
+# Install bioconductor packages
+RUN R -e "BiocManager::install(c( \
+    'AnnotationHub', \
+    'scran', \
+    'scater', \
+    'tximport'), \
+    update = FALSE)"
+
+# set final workdir for commands
+WORKDIR /home/rstudio

--- a/workflows/images/scpca_r/Dockerfile
+++ b/workflows/images/scpca_r/Dockerfile
@@ -28,6 +28,7 @@ RUN install2.r --error --deps TRUE \
 # Install bioconductor packages
 RUN R -e "BiocManager::install(c( \
     'AnnotationHub', \
+    'ensembldb', \
     'scran', \
     'scater', \
     'tximport'), \

--- a/workflows/rnaseq-ref-index/build_tx2gene_mito.R
+++ b/workflows/rnaseq-ref-index/build_tx2gene_mito.R
@@ -1,0 +1,48 @@
+#!/usr/bin/env Rscript
+
+# This script uses Bioconductor tools to download ensembl annotation data,
+# create a transcript2gene mapping file for use in salmon alevin,
+# and a output a list of mitochondrial genes for use in QC.
+
+library(AnnotationHub)
+library(magrittr)
+library(optparse)
+
+# Set up optparse options
+option_list <- list(
+  make_option(
+    opt_str = c("-t", "--t2g_out"),
+    type = "character",
+    default = "annotation/Homo_sapiens.ensembl.100.tx2gene.txt",
+    help = "File path for tx2gene output.",
+  ),
+  make_option(
+    opt_str = c("-m", "--mito_out"),
+    type = "character",
+    default = "annotation/Homo_sapiens.ensembl.100.mitogenes.txt",
+    help = "File path mitochondrial genes output.",
+  )
+)
+
+# Parse options
+opt <- parse_args(OptionParser(option_list = option_list))
+
+hub = AnnotationHub()
+# Ensembl v100 Homo Sapiens is AH79689
+ensdb = hub[["AH79689"]]
+
+# get tx to gene table
+tx <- transcriptsBy(ensdb, "gene")
+# use the versioned transcript ids
+as.data.frame(tx) %>%
+  dplyr::select(tx_id_version, gene_id) %>%
+  readr::write_tsv(opt$t2g_out,
+                   col_names = FALSE)
+
+# get genes and select mitochondrial only
+ensg <- genes(ensdb)
+mitogenes <- ensg[seqnames(ensg) == 'MT']
+
+# write out mitochondrial gene list
+writeLines(mitogenes$gene_id, opt$mito_out)
+

--- a/workflows/rnaseq-ref-index/build_tx2gene_mito.R
+++ b/workflows/rnaseq-ref-index/build_tx2gene_mito.R
@@ -4,6 +4,9 @@
 # create a transcript2gene mapping file for use in salmon alevin,
 # and a output a list of mitochondrial genes for use in QC.
 
+# Currently hard coded to Ensembl v100 Homo Sapiens, mostly because 
+# AnnotationHub is not as simple to search efficiently as I might like.
+
 library(AnnotationHub)
 library(magrittr)
 library(optparse)

--- a/workflows/rnaseq-ref-index/build_tx2gene_mito.R
+++ b/workflows/rnaseq-ref-index/build_tx2gene_mito.R
@@ -4,7 +4,7 @@
 # create a transcript2gene mapping file for use in salmon alevin,
 # and a output a list of mitochondrial genes for use in QC.
 
-# Currently hard coded to Ensembl v100 Homo Sapiens, mostly because 
+# Currently hard coded to Ensembl v100 Homo sapiens, mostly because 
 # AnnotationHub is not as simple to search efficiently as I might like.
 
 library(AnnotationHub)

--- a/workflows/rnaseq-ref-index/build_tx2gene_mito.R
+++ b/workflows/rnaseq-ref-index/build_tx2gene_mito.R
@@ -13,8 +13,8 @@ option_list <- list(
   make_option(
     opt_str = c("-t", "--t2g_out"),
     type = "character",
-    default = "annotation/Homo_sapiens.ensembl.100.tx2gene.txt",
-    help = "File path for tx2gene output.",
+    default = "annotation/Homo_sapiens.ensembl.100.tx2gene.tsv",
+    help = "File path for tx2gene output tsv file.",
   ),
   make_option(
     opt_str = c("-m", "--mito_out"),

--- a/workflows/rnaseq-ref-index/get-refs.sh
+++ b/workflows/rnaseq-ref-index/get-refs.sh
@@ -2,6 +2,9 @@
 set -euo pipefail
 
 s3_base=s3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-100
+# run R in the scpca_r dockerfile
+# docker pull ccdl/scpca_r
+rdocker="docker run --mount type=bind,target=/home/rstudio,source=$PWD ccdl/scpca_r"
 
 # Get reference fasta files and sync to S3
 wget -N -P fasta -i fasta_ref_urls.txt
@@ -9,8 +12,6 @@ aws s3 sync fasta $s3_base/fasta
 
 # get annotation files & sync
 wget -N -P annotation -i annotation_ref_urls.txt
+$rdocker Rscript build_tx2gene_mito.R
 aws s3 sync annotation $s3_base/annotation
-
-
-
 


### PR DESCRIPTION
This PR adds a script to create and add tx2gene files using `AnnotationHub` and `ensembldb`.

Closes #10

At the moment, the version of Ensembl used is hard coded, but since that is true elsewhere in this repo at the moment, it should be fine. Making this more flexible is a future project.

This code does rely on the docker container defined in #15, which should be built and tagged `ccdl/scpca_r` before running the updated version of `get-refs.sh`. In practice though, this should not need to be run often, as once the files are created and synced to S3, they should not need to change unless there is a problem.