### PR TITLE
Encrypt AMI storage

### DIFF
--- a/aws/nextflow-compute.tf
+++ b/aws/nextflow-compute.tf
@@ -19,7 +19,7 @@ resource "aws_batch_compute_environment" "nf_spot" {
     allocation_strategy = "SPOT_CAPACITY_OPTIMIZED"
     spot_iam_fleet_role = aws_iam_role.nf_spotfleet_role.arn
     bid_percentage = 100
-    max_vcpus = 100
+    max_vcpus = 256
     min_vcpus = 0
     # ccdl-nextflow-base-v1.1 image
     image_id = "ami-0a17541ba17115761"
@@ -54,7 +54,7 @@ resource "aws_batch_compute_environment" "nf_ondemand" {
       "optimal",
     ]
     allocation_strategy = "BEST_FIT"
-    max_vcpus = 20
+    max_vcpus = 32
     min_vcpus = 0
     # ccdl-nextflow-base-v1.1 image
     image_id = "ami-0a17541ba17115761"

--- a/aws/nextflow-compute.tf
+++ b/aws/nextflow-compute.tf
@@ -21,7 +21,8 @@ resource "aws_batch_compute_environment" "nf_spot" {
     bid_percentage = 100
     max_vcpus = 100
     min_vcpus = 0
-    image_id = "ami-0efd6627bb4ee4490"
+    # ccdl-nextflow-base-v1.1 image
+    image_id = "ami-0a17541ba17115761"
     # ec2_key_pair = aws_key_pair.nf_keypair.key_name
     security_group_ids = [
       aws_security_group.nf_security.id,
@@ -55,7 +56,8 @@ resource "aws_batch_compute_environment" "nf_ondemand" {
     allocation_strategy = "BEST_FIT"
     max_vcpus = 20
     min_vcpus = 0
-    image_id = "ami-0efd6627bb4ee4490"
+    # ccdl-nextflow-base-v1.1 image
+    image_id = "ami-0a17541ba17115761"
     # ec2_key_pair = aws_key_pair.nf_keypair.key_name
     security_group_ids = [
       aws_security_group.nf_security.id,

--- a/aws/nextflow-users.tf
+++ b/aws/nextflow-users.tf
@@ -13,6 +13,6 @@ resource "aws_iam_access_key" "nf_key" {
 resource "aws_iam_user_group_membership" "nf_batch" {
   user = aws_iam_user.nf_user.name
   groups = [
-    "${aws_iam_group.nf_group.name}"
+    aws_iam_group.nf_group.name
   ]
 }

--- a/aws/setup-log.md
+++ b/aws/setup-log.md
@@ -27,6 +27,7 @@ https://www.nextflow.io/docs/latest/awscloud.html#custom-ami
 Briefly:
 1. We used the base AMI _Amazon ECS-Optimized Amazon Linux AMI_. (note, not Amazon Linux 2).
 This was launched with a 50GB EBS volume for data (compared to the default 22) in addition to the base 8GB boot volume.
+All volumes are encrypted.
 
 2. All packages were updated with `sudo yum update`
 3. `/etc/sysconfig/docker-storage` edited to include `--storage-opt dm.basesize=50GB`
@@ -40,7 +41,7 @@ rm Miniconda3-latest-Linux-x86_64.sh
 ```
 5. Saved AMI from AWS web interface
 
-**The current stored AMI is** `ccdl-nextflow-base`: `ami-0efd6627bb4ee4490`
+**The current stored AMI is** `ccdl-nextflow-base-v1.1`: `ami-0a17541ba17115761`
 
 
 ## Terraform setup

--- a/aws/versions.tf
+++ b/aws/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
I have slightly modified the AMI we are using for the nextflow batch runs, as I noticed that the current one does not use encrypted EBS volumes. 

I also slightly changed the max vCPUs and updated documentation.