### PR TITLE
Add cellranger mapping workflow

### DIFF
--- a/workflows/cellranger-quant/run-cellranger.nf
+++ b/workflows/cellranger-quant/run-cellranger.nf
@@ -1,0 +1,44 @@
+#!/usr/bin/env nextflow
+nextflow.enable.dsl=2
+
+// basic parameters
+params.ref_dir = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-100'
+params.index_dir = 'cellranger_index'
+params.index_name = 'cdna'
+
+params.run_metafile = 's3://ccdl-scpca-data/sample_info/scpca-library-metadata.tsv'
+params.run_ids = "SCPCR000001,SCPCR000002" //comma separated list to be parsed into a list
+params.outdir = 's3://nextflow-ccdl-results/scpca/cellranger-quant'
+
+// build full paths
+params.index_path = "${params.ref_dir}/${params.index_dir}/${params.index_name}"
+
+process cellranger{
+  container '589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:4.0.0'
+  publishDir "${params.outdir}", mode: 'copy'
+  label 'cpus_8'
+  input:
+    tuple val(id), path(read1), path(read2)
+    path index
+  output:
+    path run_dir
+  script:
+    run_dir = "${id}-${index}"
+    """
+    cellranger
+    """
+}
+
+workflow{
+  run_ids = params.run_ids?.tokenize(',') ?: []
+  ch_reads = Channel.fromPath(params.run_metafile)
+    .splitCsv(header: true, sep: '\t')
+    .filter{it.scpca_run_id in run_ids} // use only the rows in the sample list
+    // create tuple of [sample_id, [Read1 files], [Read2 files]]
+    .map{row -> tuple(row.scpca_run_id,
+                      file("s3://${row.s3_prefix}/*_R1_*.fastq.gz"),
+                      file("s3://${row.s3_prefix}/*_R2_*.fastq.gz"),
+                      )}
+  // run cellranger
+  cellranger(ch_reads, params.index_path)
+}

--- a/workflows/cellranger-quant/run-cellranger.nf
+++ b/workflows/cellranger-quant/run-cellranger.nf
@@ -7,7 +7,7 @@ params.index_dir = 'cellranger_index'
 params.index_name = 'cdna'
 
 params.run_metafile = 's3://ccdl-scpca-data/sample_info/scpca-library-metadata.tsv'
-params.run_ids = "SCPCR000001,SCPCR000002" //comma separated list to be parsed into a list
+params.run_ids = "SCPCR000001" //comma separated list to be parsed into a list
 params.outdir = 's3://nextflow-ccdl-results/scpca/cellranger-quant'
 
 // build full paths
@@ -17,6 +17,7 @@ process cellranger{
   container '589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:4.0.0'
   publishDir "${params.outdir}", mode: 'copy'
   label 'cpus_8'
+  label 'bigdisk'
   input:
     tuple val(id), val(samples), path(fastq_dir)
     path index

--- a/workflows/cellranger-quant/run-cellranger.nf
+++ b/workflows/cellranger-quant/run-cellranger.nf
@@ -47,7 +47,8 @@ def getCRsamples(filelist){
     // [0] for the first match set, [1] for the first extracted element
     samples << (it =~ /^(.+)_S.+_L.+_R.+.fastq.gz$/)[0][1]
   }
-  // set to remove dup
+  // convert samples list to a `set` to remove duplicate entries,
+  // then join to a comma separated string.
   return samples.toSet().join(',')
 }
 

--- a/workflows/cellranger-quant/run-cellranger.nf
+++ b/workflows/cellranger-quant/run-cellranger.nf
@@ -37,7 +37,7 @@ process cellranger{
 }
 
 def getCRsamples(filelist){
-  // takesstring with semicolon separated file names
+  // takes a string with semicolon separated file names
   // returns just the 'sample info' portion of the file names,
   // as cellranger would interpret them, comma separated
   fastq_files = filelist.tokenize(';')

--- a/workflows/images/cellranger/Dockerfile
+++ b/workflows/images/cellranger/Dockerfile
@@ -5,3 +5,4 @@ WORKDIR /opt
 COPY cellranger-4.0.0.tar.gz cellranger-4.0.0.tar.gz
 RUN tar xzf cellranger-4.0.0.tar.gz && rm cellranger-4.0.0.tar.gz
 ENV PATH="/opt/cellranger-4.0.0:${PATH}"
+WORKDIR /home

--- a/workflows/nextflow.config
+++ b/workflows/nextflow.config
@@ -20,6 +20,9 @@ profiles{
         errorStrategy = { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
         maxRetries = 1
       }
+      withLabel: bigdisk {
+        queue = 'nextflow-batch-bigdisk-queue'
+      }
     }
   }
 }


### PR DESCRIPTION
This PR adds a nextflow workflow for mapping with cellranger. 

⚠️ Depends on #31 (Sort of: Code should not, but an index and docker image as described there must exist.)

While this is mostly a straightforward adaptation of existing workflows for alevin and kallisto, it incorporates components of #30 to get sample information from a metadata file. 

Notably, this includes getting a list of "samples" to pass to `cellranger`: In at least one case (the data we have!) samples that are from the same library were named so that cellranger interprets them as being from different samples. Since there is no apparent way to tell cellranger that all the files in a directory should be interpreted as the same sample, regardless of filename, we have to give cellranger a list of "sample_id" values, comma separated. We get this list by parsing the `files` field of the metadata file for each sample; extracting the portion that cellranger thinks is the sample_id, and concatenating those into a list to pass to cellranger. 

The other important modification here is the use of the `bigdisk` batch queue, which has been added to the `nextflow.config` file to be used when a particular batch job may require a large amount of temporary storage. The limited storage in the `default` queue appears to have been causing errors with execution of cellranger (it's error message was far from clear on the matter!). Giving extra space was sufficient to solve the problem.

It may be possible to speed execution by setting the `--localcores` flag to twice the vcpu count: it appears from initial testing that only ~50% of the available cpus are actually used by cellranger at any point. This has not been tested as yet, but as run time for a single sample was ~2.5 hours, it is probably worth a look.

