### PR TITLE
Dockerfile update (remove install2.r)

### DIFF
--- a/workflows/images/scpca-r/Dockerfile
+++ b/workflows/images/scpca-r/Dockerfile
@@ -22,13 +22,13 @@ RUN apt-get update -qq && apt-get -y --no-install-recommends install \
 ###############
 
 # Commonly used R packages
-RUN install2.r --error --deps TRUE \
-    optparse \
-    rprojroot
-
+RUN Rscript -e "install.packages(c( \
+    'optparse', \
+    'rprojroot') \
+    )"
 ##########################
 # Install bioconductor packages
-RUN R -e "BiocManager::install(c( \
+RUN Rscript -e "BiocManager::install(c( \
     'AnnotationHub', \
     'DropletUtils', \
     'ensembldb', \


### PR DESCRIPTION
Now that the rocker 4.0.2 repository is frozen, I wanted to rebuild the image, so along with this I also eliminated install2.R from the Dockerfile, as it has been known to keep some extra files around, bloating the image.

The difference here is small, but seemed worth doing.