### PR TITLE
Make the main readme informative

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Management and analysis tools for ALSF Single-cell Pediatric Cancer Atlas data.
   - [AWS](#aws)
     - [Installing AWS Command line tools](#installing-aws-command-line-tools)
     - [Configuring your AWS credentials](#configuring-your-aws-credentials)
+    - [AWS infrastructure](#aws-infrastructure)
 - [Running Workflows](#running-workflows)
 
 ## Environment Setup
@@ -63,6 +64,10 @@ You may want to set up your `Default region name`: most of the computing resourc
 The `Default output format` can be left as `None`
 
 The `aws configure` command will create a directory at `~/.aws` with a `config` file and a `credentials` file that will be required for `nextflow` commands to work smoothly with Batch and S3.
+
+#### AWS infrastructure
+
+The infrastructure on AWS (Batch queues, AMIs, etc.) is defined via [terraform](https://www.terraform.io) using the files in the `aws` directory. More details are described in [aws/setup-log.md](aws/setup-log.md)
 
 
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Management and analysis tools for ALSF Single-cell Pediatric Cancer Atlas data.
     - [Configuring your AWS credentials](#configuring-your-aws-credentials)
     - [AWS infrastructure](#aws-infrastructure)
 - [Running Workflows](#running-workflows)
+- [Running locally](#running-locally)
+  - [Running on AWS Batch](#running-on-aws-batch)
 
 ## Environment Setup
 
@@ -79,6 +81,10 @@ This will allow easy access to the shared `nextflow.config` file and keep all in
 In particular, `nextflow` creates a separate work directory for every task: these will appear by default (for local tasks) in the `workflows/work` directory if the command is invoked from `workflows`.
 As the work directories can get large, it is helpful to have a single location to keep track of and purge as needed.
 
+## Running locally
+
+⚠️ Running workflows in this repository locally is not something to take lightly! It is fine for a quick test, and useful for development, but note that most of the workflows here use very large data files, which will have to be downloaded locally to run. Workflow processing may require large amounts of RAM and time, so the following example commands will rarely be used, and are mostly for illustration. ⚠️
+
 The basic command to run a workflow will look something like the following:
 
 ```
@@ -93,7 +99,11 @@ In most cases, you will want to skip any cached steps that have already run: thi
 nextflow run alevin-quant/run-alevin.nf -resume
 ```
 
-To run the same workflow on AWS Batch, make sure your credentials are configured [as described above](#configuring-your-aws-credentials), and then run with the `batch` profile.
+⚠️ Again, you probably don't want to run locally unless you have a good reason and know the limitations! ⚠️
+
+### Running on AWS Batch
+
+To run the same workflow on AWS Batch, make sure your credentials are configured [as described above](#configuring-your-aws-credentials), and then run with the `batch` profile, which has been configured in `nextflow.config` for the CCDL infrastructure.
 
 ```
 nextflow run alevin-quant/run-alevin.nf -profile batch -resume

--- a/README.md
+++ b/README.md
@@ -83,12 +83,16 @@ As the work directories can get large, it is helpful to have a single location t
 
 ## Running locally
 
-⚠️ Running workflows in this repository locally is not something to take lightly! It is fine for a quick test, and useful for development, but note that most of the workflows here use very large data files, which will have to be downloaded locally to run. Workflow processing may require large amounts of RAM and time, so the following example commands will rarely be used, and are mostly for illustration. ⚠️
+⚠️⚠️⚠️
+Running workflows in this repository locally is not something to take lightly!
+It is fine for a quick test, and useful for development, but note that most of the workflows here use very large data files, which will have to be downloaded locally to run.
+Workflow processing may require large amounts of RAM and time, so the following example commands will rarely be used, and are mostly for illustration.
+⚠️⚠️⚠️
 
 The basic command to run a workflow will look something like the following:
 
 ```
-nextflow run alevin-quant/run-alevin.nf
+nextflow run checks/check-md5.nf
 ```
 
 This will run the workflow locally, using the default parameters as defined in the workflow file.
@@ -96,7 +100,7 @@ This will run the workflow locally, using the default parameters as defined in t
 In most cases, you will want to skip any cached steps that have already run: this can be done by adding the `-resume` flag.
 
 ```
-nextflow run alevin-quant/run-alevin.nf -resume
+nextflow run checks/check-md5.nf -resume
 ```
 
 ⚠️ Again, you probably don't want to run locally unless you have a good reason and know the limitations! ⚠️
@@ -106,7 +110,7 @@ nextflow run alevin-quant/run-alevin.nf -resume
 To run the same workflow on AWS Batch, make sure your credentials are configured [as described above](#configuring-your-aws-credentials), and then run with the `batch` profile, which has been configured in `nextflow.config` for the CCDL infrastructure.
 
 ```
-nextflow run alevin-quant/run-alevin.nf -profile batch -resume
+nextflow run checks/check-md5.nf -profile batch -resume
 ```
 
 (Note that the effectiveness `-resume` flag depends on location: locally cached steps will still have to run on AWS, but if they are cached on AWS, they will be skipped.)
@@ -114,11 +118,11 @@ nextflow run alevin-quant/run-alevin.nf -profile batch -resume
 If you have set up [Nextflow Tower](#nextflow-tower), you can add a flag to send progress information there:
 
 ```
-nextflow run alevin-quant/run-alevin.nf -profile batch -resume -with-tower
+nextflow run checks/check-md5.nf -profile batch -resume -with-tower
 ```
 
 Finally, if you want to change any of the parameters that are defined in a workflow, you can do so at the command line using flags that start with with a double dash `--`. For example, to use different run ids for the alevin workflow, you might use:
 
 ```
-nextflow run alevin-quant/run-alevin.nf -profile batch -resume --run-ids SCPCR000003,SCPCR000004
+nextflow run checks/check-md5.nf -profile batch -resume --run_ids SCPCR000003,SCPCR000004
 ```

--- a/README.md
+++ b/README.md
@@ -1,19 +1,49 @@
 # alsf-scpca
 Management and analysis tools for ALSF Single-cell Pediatric Cancer Atlas data.
 
-- [Environment](#environment)
-  - [Installing AWS Command line tools](#installing-aws-command-line-tools)
-  - [Configuring your AWS credentials](#configuring-your-aws-credentials)
-- [Nextflow](#nextflow)
-  - [Installing Nextflow](#installing-nextflow)
-  - [Nextflow Tower](#nextflow-tower)
+- [Environment Setup](#environment-setup)
+  - [Nextflow](#nextflow)
+    - [Installing Nextflow](#installing-nextflow)
+    - [Nextflow Tower](#nextflow-tower)
+  - [Docker](#docker)
+  - [AWS](#aws)
+    - [Installing AWS Command line tools](#installing-aws-command-line-tools)
+    - [Configuring your AWS credentials](#configuring-your-aws-credentials)
+- [Running Workflows](#running-workflows)
 
-## Environment
+## Environment Setup
+
+### Nextflow
+
+Most of the workflows in this repository are run via [Nextflow](https://www.nextflow.io).
+
+#### Installing Nextflow
+
+You can install Nextflow by following the [instructions on their page](https://www.nextflow.io/docs/latest/getstarted.html#installation).
+Be sure to follow the second step of their instructions: move the `nextflow` file to a directory in your `$PATH` for easy access.
+
+Alternatively, you can install `nextflow` via `conda` or `brew` (it may also be available in other package managers):
+- `conda install -c bioconda nextflow`
+- `brew tap brewsci/bio; brew install nextflow`
+
+#### Nextflow Tower
+
+Optionally, you can track your nextflow workflows in progress with [Nextflow Tower](https://tower.nf/).
+To use this, you will need to create an account on https://tower.nf/ (using your github account is likely simplest), then get your token value from https://tower.nf/tokens.
+You will then want to create an environment variable with this token value:
+`export TOWER_ACCESS_TOKEN=<MYTOWERTOKEN>`
+This line can be entered at the command line, but you will likely want to add it to your shell initialization file (`~/.bash_profile`, `~/.zshrc`, etc.)
+
+### Docker
+
+All of the workflows are designed to run via Docker containers for each tool. It is therefore critical that you have Docker installed for any local execution. For downloads and installation, go to https://www.docker.com/products/docker-desktop
+
+### AWS
 
 The tools in this repository are designed primarily to run on AWS via the AWS Batch system, with data stored in S3.
 To use these tools as they are currently implemented, you will therefore need an AWS account, with access to the Alex's Lemonade CCDL organization account.
 
-### Installing AWS Command line tools
+#### Installing AWS Command line tools
 Once you have your account information, you will want to install the [AWS command line interface](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html) on your local machine.
 You should be able to use either version 1 (>v1.17) or version 2 of the AWS command line tools, but these instructions have been primarily tested with v1.18.
 To install, you can follow [amazon's instructions for v2](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) or install via your favorite package manager (`pip` and `conda` will at this time install v1, `homebrew` will install v2):
@@ -21,7 +51,7 @@ To install, you can follow [amazon's instructions for v2](https://docs.aws.amazo
 - `conda install -c conda-forge awscli`
 - `brew install awscli`
 
-### Configuring your AWS credentials
+#### Configuring your AWS credentials
 
 When you set up your account, you may have gotten a paired `AWS Access Key ID` and `AWS Secret Access Key`.
 If you did not, you can login to the [aws console](https://console.aws.amazon.com/), select "My Security Credentials" from the menu that appears clicking on your username in the upper right.
@@ -34,27 +64,46 @@ The `Default output format` can be left as `None`
 
 The `aws configure` command will create a directory at `~/.aws` with a `config` file and a `credentials` file that will be required for `nextflow` commands to work smoothly with Batch and S3.
 
-## Nextflow
-
-Most of the workflows in this repository are run via [Nextflow](https://www.nextflow.io).
-
-### Installing Nextflow
-You can install Nextflow by following the [instructions on their page](https://www.nextflow.io/docs/latest/getstarted.html#installation).
-Be sure to follow the second step of their instructions: move the `nextflow` file to a directory in your `$PATH` for easy access.
-
-Alternatively, you can install `nextflow` via `conda` or `brew` (it may also be available in other package managers):
-- `conda install -c bioconda nextflow`
-- `brew tap brewsci/bio; brew install nextflow`
-
-### Nextflow Tower
-
-Optionally, you can track your nextflow workflows in progress with [Nextflow Tower](https://tower.nf/).
-To use this, you will need to create an account on https://tower.nf/ (using your github account is likely simplest), then get your token value from https://tower.nf/tokens.
-You will then want to create an environment variable with this token value:
-`export TOWER_ACCESS_TOKEN=<MYTOWERTOKEN>`
-This line can be entered at the command line, but you will likely want to add it to your shell initialization file (`~/.bash_profile`, `~/.zshrc`, etc.)
 
 
+## Running Workflows
 
+The workflows for this repository are stored in the `workflows` directory, organized by task into subdirectories.
+In general, workflows should be run from the main `workflows` directory, rather than the subdirectories.
+This will allow easy access to the shared `nextflow.config` file and keep all intermediate and log files in a single location.
+In particular, `nextflow` creates a separate work directory for every task: these will appear by default (for local tasks) in the `workflows/work` directory if the command is invoked from `workflows`.
+As the work directories can get large, it is helpful to have a single location to keep track of and purge as needed.
 
+The basic command to run a workflow will look something like the following:
 
+```
+nextflow run alevin-quant/run-alevin.nf
+```
+
+This will run the workflow locally, using the default parameters as defined in the workflow file.
+
+In most cases, you will want to skip any cached steps that have already run: this can be done by adding the `-resume` flag.
+
+```
+nextflow run alevin-quant/run-alevin.nf -resume
+```
+
+To run the same workflow on AWS Batch, make sure your credentials are configured [as described above](#configuring-your-aws-credentials), and then run with the `batch` profile.
+
+```
+nextflow run alevin-quant/run-alevin.nf -profile batch -resume
+```
+
+(Note that the effectiveness `-resume` flag depends on location: locally cached steps will still have to run on AWS, but if they are cached on AWS, they will be skipped.)
+
+If you have set up [Nextflow Tower](#nextflow-tower), you can add a flag to send progress information there:
+
+```
+nextflow run alevin-quant/run-alevin.nf -profile batch -resume -with-tower
+```
+
+Finally, if you want to change any of the parameters that are defined in a workflow, you can do so at the command line using flags that start with with a double dash `--`. For example, to use different run ids for the alevin workflow, you might use:
+
+```
+nextflow run alevin-quant/run-alevin.nf -profile batch -resume --run-ids SCPCR000003,SCPCR000004
+```

--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ This will allow easy access to the shared `nextflow.config` file and keep all in
 In particular, `nextflow` creates a separate work directory for every task: these will appear by default (for local tasks) in the `workflows/work` directory if the command is invoked from `workflows`.
 As the work directories can get large, it is helpful to have a single location to keep track of and purge as needed.
 
+Final output file locations are determined on a per-workflow basis, usually by the `params.outdir` setting within the script (possibly overridden by the `--outdir` option).
+In most cases this will be an S3 bucket within `s3://nextflow-ccdl-results`.
+
 ## Running locally
 
 ⚠️⚠️⚠️

--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ nextflow run checks/check-md5.nf -resume
 ```
 
 ⚠️ Again, you probably don't want to run locally unless you have a good reason and know the limitations! ⚠️
+If you *do* run workflows locally (only recommended for testing!), keep in mind that Nexflow will create a `work` directory in your current directory to store input, output, and intermediate files for the workflow.
+This `work` directory can get large fast, so you will want to periodically purge the subdirectories and/or delete the entire directory.
+Doing so will temporarility eliminate the benefits of `-resume`, but this is the price we pay.
+
 
 ### Running on AWS Batch
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,60 @@
 # alsf-scpca
 Management and analysis tools for ALSF Single-cell Pediatric Cancer Atlas data.
+
+- [Environment](#environment)
+  - [Installing AWS Command line tools](#installing-aws-command-line-tools)
+  - [Configuring your AWS credentials](#configuring-your-aws-credentials)
+- [Nextflow](#nextflow)
+  - [Installing Nextflow](#installing-nextflow)
+  - [Nextflow Tower](#nextflow-tower)
+
+## Environment
+
+The tools in this repository are designed primarily to run on AWS via the AWS Batch system, with data stored in S3.
+To use these tools as they are currently implemented, you will therefore need an AWS account, with access to the Alex's Lemonade CCDL organization account.
+
+### Installing AWS Command line tools
+Once you have your account information, you will want to install the [AWS command line interface](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html) on your local machine.
+You should be able to use either version 1 (>v1.17) or version 2 of the AWS command line tools, but these instructions have been primarily tested with v1.18.
+To install, you can follow [amazon's instructions for v2](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) or install via your favorite package manager (`pip` and `conda` will at this time install v1, `homebrew` will install v2):
+- `pip install awscli`
+- `conda install -c conda-forge awscli`
+- `brew install awscli`
+
+### Configuring your AWS credentials
+
+When you set up your account, you may have gotten a paired `AWS Access Key ID` and `AWS Secret Access Key`.
+If you did not, you can login to the [aws console](https://console.aws.amazon.com/), select "My Security Credentials" from the menu that appears clicking on your username in the upper right.
+Scroll down to "Access keys for CLI, SDK, & API access" and click the "Create Access Key" button.
+You will see a popup with your Access key ID and a link to show the Secret access key.
+
+In the terminal, run the command `aws configure` and when prompted paste in the `AWS Access Key ID` and `AWS Secret Access Key`.
+You may want to set up your `Default region name`: most of the computing resources used here run in `us-east-1`, but setting this to a different region should not affect most commands.
+The `Default output format` can be left as `None`
+
+The `aws configure` command will create a directory at `~/.aws` with a `config` file and a `credentials` file that will be required for `nextflow` commands to work smoothly with Batch and S3.
+
+## Nextflow
+
+Most of the workflows in this repository are run via [Nextflow](https://www.nextflow.io).
+
+### Installing Nextflow
+You can install Nextflow by following the [instructions on their page](https://www.nextflow.io/docs/latest/getstarted.html#installation).
+Be sure to follow the second step of their instructions: move the `nextflow` file to a directory in your `$PATH` for easy access.
+
+Alternatively, you can install `nextflow` via `conda` or `brew` (it may also be available in other package managers):
+- `conda install -c bioconda nextflow`
+- `brew tap brewsci/bio; brew install nextflow`
+
+### Nextflow Tower
+
+Optionally, you can track your nextflow workflows in progress with [Nextflow Tower](https://tower.nf/).
+To use this, you will need to create an account on https://tower.nf/ (using your github account is likely simplest), then get your token value from https://tower.nf/tokens.
+You will then want to create an environment variable with this token value:
+`export TOWER_ACCESS_TOKEN=<MYTOWERTOKEN>`
+This line can be entered at the command line, but you will likely want to add it to your shell initialization file (`~/.bash_profile`, `~/.zshrc`, etc.)
+
+
+
+
+

--- a/workflows/alevin-quant/run-alevin.nf
+++ b/workflows/alevin-quant/run-alevin.nf
@@ -20,11 +20,7 @@ params.mito_path = "${params.ref_dir}/${params.annotation_dir}/${params.mitolist
 
 process alevin{
   container 'quay.io/biocontainers/salmon:1.3.0--hf69c8f4_0'
-  cpus 8
-  // try dynamic memory (28.GB so 2x will fit in r4.2xlarge)
-  memory { 28.GB * task.attempt}
-  errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
-  maxRetries 1
+  label 'cpus_8'
   tag "${id}-${index}"
   publishDir "${params.outdir}"
   input:


### PR DESCRIPTION
In reviews of some of the specific workflows, it became apparent that this repo would benefit greatly from some basic instructions and description of the way files interact. This PR attempts to address this need with an expansion of the main README.md file.

Closes #37 

## For reviewers

Please read through these instructions and let me know if you think they are sufficiently detailed, or perhaps too detailed? I was not aiming for a complete description of every step, but one that would be sufficient for most internal users, with links to documentation for details about each step rather than duplicating primary sources as much as possible. 

In general, my philosophy would prefer people read the primary docs and learn about the tools in general rather than just relying the examples in the document. That said, I don't want people to be stuck on the basics they need to use the workflows with the most common options.
