### PR TITLE
Increase disk space for md5 checks

### DIFF
--- a/workflows/checks/check-md5.nf
+++ b/workflows/checks/check-md5.nf
@@ -12,6 +12,7 @@ params.run_ids = "SCPCR000001,SCPCR000002"
 
 process check_md5{
   container 'ubuntu:20.04'
+  label 'bigdisk'
   publishDir "${params.outdir}"
   input:
     tuple val(id), val(md5_file), path(files)


### PR DESCRIPTION
The current check-md5 workflow requires that all files in a directory be downloaded to the running computer before md5sums are calculated and checked. This isn't really ideal, and I would like to improve it (issue incoming), but it has worked so far... until the files in a directory get too large to fit on the running batch computer. When that happens, the files fail to download and the workflow job fails.

To better allow for large directories to be processed, this change adds the `bigdisk` label to the `check_md5` process. This instructs AWS Batch to use the  `nextflow-batch-bigdisk-queue` queue, which allocates much more disk space per job, reducing the chances for this error to occur.