### PR TITLE
Make the md5 process a bit more robust, and print failures

### DIFF
--- a/aws/nextflow-launch-templates.tf
+++ b/aws/nextflow-launch-templates.tf
@@ -21,7 +21,7 @@ resource "aws_launch_template" "nf_lt_bigdisk" {
   block_device_mappings {
     device_name = "/dev/xvda"
     ebs {
-      volume_size = 500
+      volume_size = 1000
       encrypted = true
       delete_on_termination = true
     }

--- a/workflows/checks/check-md5.nf
+++ b/workflows/checks/check-md5.nf
@@ -13,6 +13,11 @@ params.run_ids = "SCPCR000001,SCPCR000002"
 process check_md5{
   container 'ubuntu:20.04'
   label 'bigdisk'
+  // tasks sometimes fail due to disk space but we can't specify that directly
+  errorStrategy 'retry' 
+  maxRetries = 1
+  cpus { 1 + 3 * (task.attempt - 1)  } //use more CPUs to take over a machine if failure
+
   publishDir "${params.outdir}"
   input:
     tuple val(id), val(md5_file), path(files)


### PR DESCRIPTION
This PR has a couple of changes to deal with the cases which pop up when the disk fills up downloading files to check md5s (I would like to not download the files at all, but that would require a more extensive rewrite). 

The other thing that this adds is a set of final output checks that will print any md5 mismatches to stdout when the workflow is run.  This can save the user from having to scan the output file manually to identify any failures.