### PR TITLE
New docker image for cellranger 6.0.0

### DIFF
--- a/images/cellranger/Dockerfile
+++ b/images/cellranger/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:20.04
 LABEL maintainer="ccdl@alexslemonade.org"
 
 WORKDIR /opt
-COPY cellranger-4.0.0.tar.gz cellranger-4.0.0.tar.gz
-RUN tar xzf cellranger-4.0.0.tar.gz && rm cellranger-4.0.0.tar.gz
-ENV PATH="/opt/cellranger-4.0.0:${PATH}"
+COPY cellranger-6.0.0.tar.gz cellranger-6.0.0.tar.gz
+RUN tar xzf cellranger-6.0.0.tar.gz && rm cellranger-6.0.0.tar.gz
+ENV PATH="/opt/cellranger-6.0.0:${PATH}"
 
 WORKDIR /home

--- a/images/cellranger/README.md
+++ b/images/cellranger/README.md
@@ -4,12 +4,12 @@ This folder contains a Dockerfile for the cellranger analysis.
 ## Building the image
 
 In order to build this image, the cellranger archive component must be downloaded separately to comply with licensing, and should be placed in this folder (`images/cellranger`).
-The current version of this file is `cellranger-4.0.0.tar.gz` and can be downloaded from [10X Genomics Website](https://support.10xgenomics.com/single-cell-gene-expression/software/downloads/latest) after agreeing to their license terms.
+The current version of this file is `cellranger-6.0.0.tar.gz` and can be downloaded from [10X Genomics Website](https://support.10xgenomics.com/single-cell-gene-expression/software/downloads/6.0) after agreeing to their license terms.
 
 Following download of cellranger, you can build the image running the following command from this `images/cellranger` working directory:
 
 ```
-docker build . -t scpca-cellranger:4.0.0
+docker build . -t scpca-cellranger:6.0.0
 ```
 
 At this point, the image should be ready for use on the local machine.
@@ -40,9 +40,9 @@ If the updated image needs to be pushed to AWS ECR, you can follow the outline s
 The current image was pushed with the following commands.
 
 ```
-docker tag scpca-cellranger:4.0.0 589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:latest
-docker tag scpca-cellranger:4.0.0 589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:4.0.0
-docker push 589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:4.0.0
+docker tag scpca-cellranger:6.0.0 589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:latest
+docker tag scpca-cellranger:6.0.0 589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:6.0.0
+docker push 589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:6.0.0
 docker push 589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:latest
 ```
 

--- a/images/cellranger/cellranger4.docker
+++ b/images/cellranger/cellranger4.docker
@@ -1,0 +1,9 @@
+FROM ubuntu:20.04
+LABEL maintainer="ccdl@alexslemonade.org"
+
+WORKDIR /opt
+COPY cellranger-4.0.0.tar.gz cellranger-4.0.0.tar.gz
+RUN tar xzf cellranger-4.0.0.tar.gz && rm cellranger-4.0.0.tar.gz
+ENV PATH="/opt/cellranger-4.0.0:${PATH}"
+
+WORKDIR /home


### PR DESCRIPTION
This PR addresses #55 which requires addition of a new docker image for cellranger 6.0.0 to be used for benchmarking pre-processing of ScPCA data. 

The old dockerfile used for cellranger 4.0.0 was moved to a new file named `cellranger4.docker` and the new `Dockerfile` contains the image for running cellranger 6.0.0. The docker image was built and tested using the following command: `docker run -it --rm scpca-cellranger:6.0.0 cellranger testrun --id=tiny` to ensure that it successfully can run cellranger 6.0.0. 

Additionally, it appears that the reference files for cellranger have not been updated since July 7, 2020 and the reference files located on S3 were added in October, 2020. The STARsolo website also doesn't mention any need for a new reference index. I think it is safe to assume that we do not need to update the reference. https://support.10xgenomics.com/single-cell-gene-expression/software/downloads/latest

Things that have not been done: 
- this updated image has not been pushed to AWS ECR
- the nextflow workflow `workflows/cellranger-quant/run-cellranger.nf` has not been updated yet and will be addressed in a new issue