### PR TITLE
Updated alevin workflows to include most recent Salmon 1.4.0/Alevin-Fry

### DIFF
--- a/images/cellranger/Dockerfile
+++ b/images/cellranger/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:20.04
 LABEL maintainer="ccdl@alexslemonade.org"
 
 WORKDIR /opt
-COPY cellranger-4.0.0.tar.gz cellranger-4.0.0.tar.gz
-RUN tar xzf cellranger-4.0.0.tar.gz && rm cellranger-4.0.0.tar.gz
-ENV PATH="/opt/cellranger-4.0.0:${PATH}"
+COPY cellranger-6.0.0.tar.gz cellranger-6.0.0.tar.gz
+RUN tar xzf cellranger-6.0.0.tar.gz && rm cellranger-6.0.0.tar.gz
+ENV PATH="/opt/cellranger-6.0.0:${PATH}"
 
 WORKDIR /home

--- a/images/cellranger/cellranger4.docker
+++ b/images/cellranger/cellranger4.docker
@@ -1,0 +1,9 @@
+FROM ubuntu:20.04
+LABEL maintainer="ccdl@alexslemonade.org"
+
+WORKDIR /opt
+COPY cellranger-4.0.0.tar.gz cellranger-4.0.0.tar.gz
+RUN tar xzf cellranger-4.0.0.tar.gz && rm cellranger-4.0.0.tar.gz
+ENV PATH="/opt/cellranger-4.0.0:${PATH}"
+
+WORKDIR /home

--- a/workflows/alevin-quant/run-alevin-fry.nf
+++ b/workflows/alevin-quant/run-alevin-fry.nf
@@ -56,7 +56,6 @@ process alevin{
 //generate permit list from RAD input 
 process generate_permit{
   container 'ghcr.io/alexslemonade/scpca-alevin-fry:latest'
-  label 'cpus_8'
   publishDir "${params.outdir}"
   input:
     path run_dir
@@ -68,7 +67,7 @@ process generate_permit{
     """
     alevin-fry generate-permit-list \
       -i ${run_dir} \
-      --expected-ori either \
+      --expected-ori fw \
       -o ${run_dir} \
       -k
     """
@@ -84,9 +83,8 @@ process collate_quant{
     path run_dir
     path tx2gene
   output: 
-    path counts
+    path run_dir
   script:
-    counts = "${run_dir}/counts"
     """
     alevin-fry collate \
       --input-dir ${run_dir} \
@@ -96,7 +94,7 @@ process collate_quant{
     alevin-fry quant \
      --input-dir ${run_dir} \
      --tg-map ${tx2gene} \
-     --output-dir ${counts} \
+     --output-dir ${run_dir} \
      -t ${task.cpus}
     """
 }

--- a/workflows/alevin-quant/run-alevin-fry.nf
+++ b/workflows/alevin-quant/run-alevin-fry.nf
@@ -14,7 +14,7 @@ params.run_metafile = 's3://ccdl-scpca-data/sample_info/scpca-library-metadata.t
 // or "All" to process all samples in the metadata file
 params.run_ids = "SCPCR000001,SCPCR000002"
 
-params.outdir = 's3://nextflow-ccdl-results/scpca/alevin-quant'
+params.outdir = 's3://nextflow-ccdl-results/scpca/alevin-fry-quant'
 
 // build full paths
 params.index_path = "${params.ref_dir}/${params.index_dir}/${params.index_name}"

--- a/workflows/alevin-quant/run-alevin-fry.nf
+++ b/workflows/alevin-quant/run-alevin-fry.nf
@@ -4,7 +4,7 @@ nextflow.enable.dsl=2
 // run parameters
 params.ref_dir = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-100'
 params.index_dir = 'salmon_index'
-params.index_name = 'txome_k31_full_sa'
+params.index_name = 'txome_k31'
 params.annotation_dir = 'annotation'
 params.t2g = 'Homo_sapiens.ensembl.100.tx2gene.tsv'
 params.mitolist = 'Homo_sapiens.ensembl.100.mitogenes.txt'
@@ -76,7 +76,7 @@ process generate_permit{
 
 // given permit list and barcode mapping, collate RAD file 
 // then quantify collated RAD file
-process collate{
+process collate_quant{
   container 'ghcr.io/alexslemonade/scpca-alevin-fry:latest'
   label 'cpus_8'
   publishDir "${params.outdir}"
@@ -102,7 +102,6 @@ process collate{
 }
 // run quant command with default full resolution strategy 
 
-
 workflow{
   run_ids = params.run_ids?.tokenize(',') ?: []
   run_all = run_ids[0] == "All"
@@ -121,5 +120,5 @@ workflow{
   // generate permit list from alignment 
   generate_permit(alevin.out)
   // collate RAD files and create gene x cell matrix
-  collate(generate_permit.out, params.t2g_path)
+  collate_quant(generate_permit.out, params.t2g_path)
 }

--- a/workflows/alevin-quant/run-alevin-fry.nf
+++ b/workflows/alevin-quant/run-alevin-fry.nf
@@ -1,0 +1,147 @@
+#!/usr/bin/env nextflow
+nextflow.enable.dsl=2
+
+// run parameters
+params.ref_dir = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-100'
+params.index_dir = 'salmon_index'
+params.index_name = 'txome_k31_full_sa'
+params.annotation_dir = 'annotation'
+params.t2g = 'Homo_sapiens.ensembl.100.tx2gene.tsv'
+params.mitolist = 'Homo_sapiens.ensembl.100.mitogenes.txt'
+
+params.run_metafile = 's3://ccdl-scpca-data/sample_info/scpca-library-metadata.tsv'
+// run_ids are comma separated list to be parsed into a list of run ids,
+// or "All" to process all samples in the metadata file
+params.run_ids = "SCPCR000001,SCPCR000002"
+
+params.outdir = 's3://nextflow-ccdl-results/scpca/alevin-quant'
+
+// build full paths
+params.index_path = "${params.ref_dir}/${params.index_dir}/${params.index_name}"
+params.t2g_path = "${params.ref_dir}/${params.annotation_dir}/${params.t2g}"
+params.mito_path = "${params.ref_dir}/${params.annotation_dir}/${params.mitolist}"
+
+// generates RAD file using alevin
+process alevin{
+  container 'quay.io/biocontainers/salmon:1.4.0--hf69c8f4_0'
+  label 'cpus_8'
+  tag "${id}-${index}"
+  publishDir "${params.outdir}"
+  input:
+    tuple val(id), path(read1), path(read2)
+    path index
+    path tx2gene
+  output:
+    path run_dir
+  script:
+    run_dir = "${id}-${index}"
+  // run alevin like normal with the --justAlign flag 
+  // creates output directory with RAD file needed for alevin-fry
+    """
+    mkdir -p ${run_dir}/alevin
+    salmon alevin \
+      -l ISR \
+      --chromium \
+      -1 ${read1} \
+      -2 ${read2} \
+      -i ${index} \
+      --tgMap ${tx2gene} \
+      -o ${run_dir}/alevin \
+      -p ${task.cpus} \
+      --dumpFeatures \
+      --justAlign \
+    """
+}
+
+//generate permit list from RAD input 
+process generate_permit{
+  container 'quay.io/biocontainers/salmon:1.4.0--hf69c8f4_0'
+  label 'cpus_8'
+  tag "${id}-${index}" // do we need this? 
+  publishDir "${params.outdir}"
+  input:
+    path run_dir
+  output:
+    path permit_list
+  script:
+    permit_list = "${run_dir}/permit_list"
+  // expected-ori either signifies no filtering of alignments 
+  // based on orientation, not sure if this is what we want? 
+    """
+    mkdir -p ${run_dir}/permit_list
+    alevin-fry generate-permit-list \ 
+      --input ${run_dir}/alevin \
+      --output-dir ${run_dir}/permit_list \
+      --expected-ori either \
+      --knee-distance \
+    """
+}
+
+// given permit list and barcode mapping, collate RAD file 
+process collate{
+  container 'quay.io/biocontainers/salmon:1.4.0--hf69c8f4_0'
+  label 'cpus_8'
+  publishDir "${params.outdir}"
+  input: 
+    path permit_list
+    path run_dir
+  output: 
+    path collate_file
+  script:
+    collate_file = "${run_dir}/permit_list/map.collated.rad"
+    """
+    alevin-fry collate \
+      -r ${run_dir}/alevin \
+      -i ${permit_list} \
+    """
+}
+
+// quantify collated RAD file
+process quant{
+  container 'quay.io/biocontainers/salmon:1.4.0--hf69c8f4_0'
+  label 'cpus_8'
+  publishDir "${params.outdir}"
+  input: 
+    path collate_file
+    path tx2gene
+  output:
+    path counts
+  script:
+    counts = "${run_dir}/counts"
+    // run quant command with default full resolution strategy 
+    // gene-level, UMI-deduplicated, equivalence class counts file + gene counts matrix output
+    """
+      mkdir -p ${run_dir}/counts
+
+      alevin-fry quant \
+        -i ${collate_file} \
+        --tgMap ${tx2gene} \
+        -o ${run_dir}/counts \
+        -p ${task.cpus} \
+        --dump-eqclasses \
+    """
+}
+
+
+workflow{
+  run_ids = params.run_ids?.tokenize(',') ?: []
+  run_all = run_ids[0] == "All"
+  ch_reads = Channel.fromPath(params.run_metafile)
+    .splitCsv(header: true, sep: '\t')
+    .filter{it.technology == "10Xv3"} // only 10X data
+    // use only the rows in the sample list
+    .filter{run_all || (it.scpca_run_id in run_ids)}
+    // create tuple of [sample_id, [Read1 files], [Read2 files]]
+    .map{row -> tuple(row.scpca_run_id,
+                      file("s3://${row.s3_prefix}/*_R1_*.fastq.gz"),
+                      file("s3://${row.s3_prefix}/*_R2_*.fastq.gz"),
+                      )}
+  // run Alevin
+  alevin(ch_reads, params.index_path, params.t2g_path)
+  // generate permit list from alignment 
+  generate_permit(alevin.out)
+  // collate RAD files
+  collate(generate_permit.out, alevin.out)
+  // create gene x cell matrix
+  quant(collate.out, params.t2g_path)
+}

--- a/workflows/alevin-quant/run-alevin.nf
+++ b/workflows/alevin-quant/run-alevin.nf
@@ -22,7 +22,7 @@ params.t2g_path = "${params.ref_dir}/${params.annotation_dir}/${params.t2g}"
 params.mito_path = "${params.ref_dir}/${params.annotation_dir}/${params.mitolist}"
 
 process alevin{
-  container 'quay.io/biocontainers/salmon:1.3.0--hf69c8f4_0'
+  container 'quay.io/biocontainers/salmon:1.4.0--hf69c8f4_0'
   label 'cpus_8'
   tag "${id}-${index}"
   publishDir "${params.outdir}"

--- a/workflows/cellranger-quant/run-cellranger4.nf
+++ b/workflows/cellranger-quant/run-cellranger4.nf
@@ -16,7 +16,7 @@ params.outdir = 's3://nextflow-ccdl-results/scpca/cellranger-quant'
 params.index_path = "${params.ref_dir}/${params.index_dir}/${params.index_name}"
 
 process cellranger{
-  container '589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:6.0.0'
+  container '589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:4.0.0'
   publishDir "${params.outdir}", mode: 'copy'
   label 'cpus_8'
   label 'bigdisk'
@@ -63,7 +63,7 @@ workflow{
     .filter{it.technology == "10Xv3"} // only 10X data
     // use only the rows in the sample list
     .filter{run_all || (it.scpca_run_id in run_ids)}
-    // create tuple of [sample_id, sample_names, fastq dir]
+    // create tuple of [sample_id, fastq dir]
     .map{row -> tuple(row.scpca_run_id,
                       getCRsamples(row.files),
                       file("s3://${row.s3_prefix}")


### PR DESCRIPTION
Related to #51. I updated the current workflow for Alevin, `workflows/alevin-quant/run-alevin.nf` to include most up to date Salmon container. Tag: 1.4.0--h84f40af_1 found here: https://quay.io/repository/biocontainers/salmon?tab=tags

Additionally, I added a new workflow that uses Alevin-fry and follows the steps outlined in the [documentation here](https://alevin-fry.readthedocs.io/en/latest/index.html). 

A few places that had options for arguments that I wasn't 100 percent positive about in building the alevin-fry workflow:

- After alignment, there is a RAD file (similar to a BAM file) that is output and used as input for the next step to generate a a list of "true" cells that are identified. At this point, reads are filtered based on sense/ anti-sense alignment, but you can include an option to keep all alignments. Currently, I left the option as "either", meaning reads will not be filtered by directionality. However, cellranger does filter and only include reads in the sense direction. I couldn't find Should that also be the approach used here? 

- Which option do we want to use to determine the "true" barcodes? I went with the --knee-distance option which uses an iterative algorithm to look for an optimal number of barcodes/cell by looking for the knee in the cumulative distribution function graph. It appears that this is slightly different from using --expect-cells which uses the number of cells as a hint to choose the cutoff around that value. This option seemed like the most standard and is similar to cellranger and kallisto (from what I can interpret, except they use the 10x whitelist and this method does not). The other two options require either a desired number of cells (--force-cells) or a provided list of true barcodes to search for and didn't seem feasible for a reproducible pipeline. 

- For the quantification step there are multiple different resolution strategies for gene quantification that could be chosen: I have it currently set up to use the full resolution strategy as that is the default. This strategy builds a graph among transcripts with UMI's within an edit distance of 1. It looks for a parsimonious cover for the graph, and then looks to assign the deduplicated reads to genes with the most parsimonious cover. For reads that are multi-mapping, they are probabilistically resolved using an expectation maximization algorithm. More details about quant methods can be [found here. ](https://alevin-fry.readthedocs.io/en/latest/quant.html) This is one of the differences across the methods as cellranger throws out reads that map to multiple genes and Kallisto uses a different UMI collapse method than alevin. There are similar resolution methods to cellranger that alevin-fry has that we could use for direct comparison? Or keep with the defualt as that may add to part of the specific benefit of using Alevin over other methods? 

Currently performing a test run on AWS batch on 2 samples using the new `run-alevin-fry.nf` workflow to ensure that it works before asking for a formal review. 