### PR TITLE
Add 10Xv2 support to kallisto workflow

### DIFF
--- a/workflows/kallisto-quant/run-kallisto.nf
+++ b/workflows/kallisto-quant/run-kallisto.nf
@@ -127,7 +127,7 @@ workflow{
   run_all = run_ids[0] == "All"
   samples_ch = Channel.fromPath(params.run_metafile)
     .splitCsv(header: true, sep: '\t')
-    .filter{it.technology == "10Xv3"} // only 10X data
+    .filter{it.technology in barcodes} // only 10X data
     // use only the rows in the sample list
     .filter{run_all || (it.scpca_run_id in run_ids)}
   // create tuple of [sample_id, technology, [Read1 files], [Read2 files]]

--- a/workflows/kallisto-quant/run-kallisto.nf
+++ b/workflows/kallisto-quant/run-kallisto.nf
@@ -28,7 +28,6 @@ process kallisto_bus{
   container 'quay.io/biocontainers/kallisto:0.46.2--h4f7b962_1'
   label 'cpus_8'
   tag "${id}-${index}"
-  publishDir "${params.outdir}"
   input:
     tuple val(id), val(tech), path(read1), path(read2)
     path index
@@ -58,7 +57,6 @@ process kallisto_bus{
 process bustools_whitelist{
   container 'quay.io/biocontainers/bustools:0.40.0--h4f7b962_0'
   label 'cpus_8'
-  publishDir "${params.outdir}"
   input:
     path run_dir
   output:

--- a/workflows/kallisto-quant/run-kallisto.nf
+++ b/workflows/kallisto-quant/run-kallisto.nf
@@ -8,10 +8,14 @@ params.index_name = 'txome_k31'
 params.annotation_dir = 'annotation'
 params.t2g = 'Homo_sapiens.ensembl.100.tx2gene.tsv'
 params.mitolist = 'Homo_sapiens.ensembl.100.mitogenes.txt'
-params.barcodes = 's3://nextflow-ccdl-data/reference/10X/barcodes/3M-february-2018.txt' // 10X v3 barcodes
+params.barcode_dir = 's3://nextflow-ccdl-data/reference/10X/barcodes' 
+// 10X barcode files
+barcodes = ['10Xv2': '737K-august-2016.txt',
+            '10Xv3': '3M-february-2018.txt',
+            '10Xv3.1': '3M-february-2018.txt']
 
 params.run_metafile = 's3://ccdl-scpca-data/sample_info/scpca-library-metadata.tsv'
-params.run_ids = "SCPCR000001,SCPCR000002" //comma separated list to be parsed into a list
+params.run_ids = "SCPCR000003" //comma separated list to be parsed into a list
 params.outdir = 's3://nextflow-ccdl-results/scpca/kallisto-quant'
 
 // build full paths
@@ -26,7 +30,7 @@ process kallisto_bus{
   tag "${id}-${index}"
   publishDir "${params.outdir}"
   input:
-    tuple val(id), path(read1), path(read2)
+    tuple val(id), val(tech), path(read1), path(read2)
     path index
   output:
     path run_dir
@@ -34,12 +38,16 @@ process kallisto_bus{
     run_dir = "${id}-${index}"
     // interleave read1 & read2 file paths
     reads = [read1, read2].transpose().flatten().join(' ')
+    // translate for kallisto technology flag
+    tech_x = ['10Xv2': '10xv2',
+              '10Xv3': '10xv3',
+              '10Xv3.1': '10xv3']
     """
     mkdir -p ${run_dir}/bus
     kallisto bus \
       -i ${index} \
       -o ${run_dir}/bus \
-      -x 10xv3 \
+      -x ${tech_x[tech]} \
       -t ${task.cpus} \
       ${reads}
     """
@@ -54,17 +62,17 @@ process bustools_whitelist{
   input:
     path run_dir
   output:
-    path whitelist
+    path barcode_file
   script:
-    whitelist = "${run_dir}/bus/whitelist.txt"
+    barcode_file = "${run_dir}/bus/barcodes.txt"
     """
     bustools sort \
       -o output.sorted.bus \
       -t ${task.cpus} \
       ${run_dir}/bus/output.bus
     bustools whitelist \
-    -o ${whitelist} \
-    output.sorted.bus
+      -o ${barcode_file} \
+      output.sorted.bus
     """
 }
 
@@ -74,14 +82,14 @@ process bustools_correct{
   publishDir "${params.outdir}"
   input:
     path run_dir
-    path whitelist
+    path barcode_file
   output:
     path run_dir
   script:
     """
     bustools correct \
       -p \
-      -w ${whitelist} \
+      -w ${barcode_file} \
       ${run_dir}/bus/output.bus \
     | bustools sort \
       -o ${run_dir}/bus/output.corrected.bus \
@@ -117,20 +125,24 @@ process bustools_count{
 workflow{
   run_ids = params.run_ids?.tokenize(',') ?: []
   run_all = run_ids[0] == "All"
-  ch_reads = Channel.fromPath(params.run_metafile)
+  samples_ch = Channel.fromPath(params.run_metafile)
     .splitCsv(header: true, sep: '\t')
     .filter{it.technology == "10Xv3"} // only 10X data
     // use only the rows in the sample list
     .filter{run_all || (it.scpca_run_id in run_ids)}
-    // create tuple of [sample_id, [Read1 files], [Read2 files]]
+  // create tuple of [sample_id, technology, [Read1 files], [Read2 files]]
+  reads_ch = samples_ch
     .map{row -> tuple(row.scpca_run_id,
+                      row.technology,
                       file("s3://${row.s3_prefix}/*_R1_*.fastq.gz"),
                       file("s3://${row.s3_prefix}/*_R2_*.fastq.gz"),
                       )}
+  barcodes_ch = samples_ch
+    .map{row -> file("${params.barcode_dir}/${barcodes[row.technology]}")}
   // run kallisto
-  kallisto_bus(ch_reads, params.index_path)
+  kallisto_bus(reads_ch, params.index_path)
   // correct busfiles using expected barcodes
-  bustools_correct(kallisto_bus.out, params.barcodes)
+  bustools_correct(kallisto_bus.out, barcodes_ch)
   // count genes
   bustools_count(bustools_correct.out, params.t2g_path)
 }


### PR DESCRIPTION
This PR adds a bit more flexibility to the kallisto workflow, starting work on https://github.com/AlexsLemonade/alsf-scpca/issues/52.  The main thing is that it now supports 10Xv2 and 10Xv3.1. It does this by now having a map (dictionary) of the 10X barcode files that can be checked when correcting cell barcodes as well as filtering to technology types that are in that list. 

I checked that the workflow ran as expected with SCPCR000119 (v3.1) & SCPCR000120 (v2), though I have not looked at the actual count results. 

In the process of  testing, I learned that `bustools count` will segfault if given the results from a `bustools correct` step where the barcode file is not found. You'd think `bustools correct` or the following `bustools sort` would fail, but they don't.

I also did a bit of cleanup, removing some unnecessary publish steps. I am still publishing the full `bus` directory, but only once now.