### PR TITLE
Update cellranger to allow flexibility for all 10x technology

### DIFF
--- a/images/scpca-r/Dockerfile
+++ b/images/scpca-r/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/tidyverse:4.0.2
+FROM rocker/tidyverse:4.0.5
 LABEL maintainer="ccdl@alexslemonade.org"
 
 ### Install apt-getable packages to start
@@ -17,7 +17,18 @@ RUN apt-get update -qq && apt-get -y --no-install-recommends install \
     libreadline-dev \
     libudunits2-dev
 
+
 #### R packages
+###############
+# this comes first since bioconductor packages are 
+# dependent on updated matrixStats
+RUN Rscript -e "install.packages(c( \
+    'here', \
+    'optparse', \
+    'rprojroot', \
+    'matrixStats') \
+    )"
+
 ##########################
 # Install bioconductor packages
 RUN Rscript -e "BiocManager::install(c( \
@@ -27,16 +38,12 @@ RUN Rscript -e "BiocManager::install(c( \
     'fishpond', \
     'scran', \
     'scater', \
-    'tximport'), \
+    'tximport', \
+    'eisaR', \
+    'Biostrings', \
+    'GenomicFeatures', \
+    'BSgenome'), \
     update = FALSE)"
-
-###############
-# Other R packages
-RUN Rscript -e "install.packages(c( \
-    'here', \
-    'optparse', \
-    'rprojroot') \
-    )"
 
 # set final workdir for commands
 WORKDIR /home/rstudio

--- a/workflows/cellranger-quant/run-cellranger.nf
+++ b/workflows/cellranger-quant/run-cellranger.nf
@@ -12,6 +12,9 @@ params.run_metafile = 's3://ccdl-scpca-data/sample_info/scpca-library-metadata.t
 params.run_ids = "SCPCR000001,SCPCR000002"
 params.outdir = 's3://nextflow-ccdl-results/scpca/cellranger-quant'
 
+//technology options
+technology = ["10Xv2", "10Xv3", "10Xv3.1"]
+
 // build full paths
 params.index_path = "${params.ref_dir}/${params.index_dir}/${params.index_name}"
 
@@ -47,7 +50,7 @@ def getCRsamples(filelist){
   fastq_files.each{
     // append sample names to list, using regex to extract element before S001, etc.
     // [0] for the first match set, [1] for the first extracted element
-    samples << (it =~ /^(.+)_S.+_L.+_R.+.fastq.gz$/)[0][1]
+    samples << (it =~ /^(.+)_S.+_L.+_[R|I].+.fastq.gz$/)[0][1]
   }
   // convert samples list to a `set` to remove duplicate entries,
   // then join to a comma separated string.
@@ -60,7 +63,7 @@ workflow{
   run_all = run_ids[0] == "All"
   ch_reads = Channel.fromPath(params.run_metafile)
     .splitCsv(header: true, sep: '\t')
-    .filter{it.technology == "10Xv3"} // only 10X data
+    .filter{it.technology in technology} // only 10X data
     // use only the rows in the sample list
     .filter{run_all || (it.scpca_run_id in run_ids)}
     // create tuple of [sample_id, sample_names, fastq dir]

--- a/workflows/rnaseq-ref-index/annotation_ref_urls.txt
+++ b/workflows/rnaseq-ref-index/annotation_ref_urls.txt
@@ -1,1 +1,1 @@
-ftp://ftp.ensembl.org//pub/release-100/gtf/homo_sapiens/Homo_sapiens.GRCh38.100.gtf.gz
+ftp://ftp.ensembl.org//pub/release-103/gtf/homo_sapiens/Homo_sapiens.GRCh38.103.gtf.gz

--- a/workflows/rnaseq-ref-index/fasta_ref_urls.txt
+++ b/workflows/rnaseq-ref-index/fasta_ref_urls.txt
@@ -1,4 +1,4 @@
-ftp://ftp.ensembl.org/pub/release-100/fasta/homo_sapiens/dna/Homo_sapiens.GRCh38.dna.toplevel.fa.gz
-ftp://ftp.ensembl.org/pub/release-100/fasta/homo_sapiens/dna/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz
-ftp://ftp.ensembl.org/pub/release-100/fasta/homo_sapiens/cdna/Homo_sapiens.GRCh38.cdna.all.fa.gz
-ftp://ftp.ensembl.org/pub/release-100/fasta/homo_sapiens/ncrna/Homo_sapiens.GRCh38.ncrna.fa.gz
+ftp://ftp.ensembl.org/pub/release-103/fasta/homo_sapiens/dna/Homo_sapiens.GRCh38.dna.toplevel.fa.gz
+ftp://ftp.ensembl.org/pub/release-103/fasta/homo_sapiens/dna/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz
+ftp://ftp.ensembl.org/pub/release-103/fasta/homo_sapiens/cdna/Homo_sapiens.GRCh38.cdna.all.fa.gz
+ftp://ftp.ensembl.org/pub/release-103/fasta/homo_sapiens/ncrna/Homo_sapiens.GRCh38.ncrna.fa.gz

--- a/workflows/rnaseq-ref-index/get-refs.sh
+++ b/workflows/rnaseq-ref-index/get-refs.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
-s3_base=s3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-100
+# update to use most recent genome release
+s3_base=s3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-103
 # run R in the scpca_r dockerfile
 # docker pull ghcr.io/alexslemonade/scpca_r
-rdocker="docker run --mount type=bind,target=/home/rstudio,source=$PWD ghcr.io/alexslemonade/scpca_r"
+ rdocker="docker run --mount type=bind,target=/home/rstudio,source=$PWD ghcr.io/alexslemonade/scpca_r:v2"
 
 # Get reference fasta files and sync to S3
 wget -N -P fasta -i fasta_ref_urls.txt
@@ -18,5 +19,7 @@ aws s3 sync fasta $s3_base/fasta
 # get annotation files & sync
 wget -N -P annotation -i annotation_ref_urls.txt
 $rdocker Rscript build_tx2gene_mito.R
+$rdocker Rscript make_pre_mrna_fasta.R
 aws s3 sync annotation $s3_base/annotation
+aws s3 sync expanded_annotation $s3_base/expanded_annotation
 

--- a/workflows/rnaseq-ref-index/make_pre_mrna_fasta.R
+++ b/workflows/rnaseq-ref-index/make_pre_mrna_fasta.R
@@ -1,0 +1,96 @@
+#!/usr/bin/env Rscript
+
+# This script takes the input reference fasta of the genome and the 
+# corresponding gtf file, identifies the regions of interest corresponding
+# to spliced transcripts and unspliced transcripts, then subsets the genome 
+# and gtf for only those particular regions, and finally outputs an expanded.fa, 
+# expanded.gtf, and expanded.tx2gene.tsv all corresponding to the genomic 
+# regions with spliced and unspliced transcripts. 
+
+# load needed packages
+library(magrittr)
+library(optparse)
+library(eisaR)
+library(Biostrings)
+library(GenomicFeatures)
+library(BSgenome)
+
+# Set up optparse options
+option_list <- list(
+  make_option(
+    opt_str = c("-f", "--gtf"),
+    type = "character",
+    default = "annotation/Homo_sapiens.GRCh38.103.gtf.gz",
+    help = "File path for input gtf file",
+  ),
+  make_option(
+    opt_str = c("-g", "--genome"),
+    type = "character",
+    default = "fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz",
+    help = "File path for reference fasta file",
+  ), 
+  make_option(
+    opt_str = c("-O", "--output_dir"),
+    type = "character",
+    default = "expanded_annotation",
+    help = "Directory to write output files",
+  )
+)
+
+# Parse options
+opt <- parse_args(OptionParser(option_list = option_list))
+
+# Make output paths 
+expanded_fasta <- file.path(opt$output_dir, 
+                            "ensembl.GRCh38.annotation.expanded.fa")
+expanded_gtf <- file.path(opt$output_dir, 
+                          "ensembl.GRCh38.annotation.expanded.gtf")
+expanded_tx2gene <- file.path(opt$output_dir, 
+                              "ensembl.GRCh38.annotation.expanded.tx2gene.tsv")
+
+# Check for output directory 
+if (!dir.exists(opt$output_dir)) {
+  dir.create(opt$output_dir)
+}
+
+# extract GRanges object containing genomic coordinates of each 
+# annotated transcript and intron 
+gtf <- opt$gtf
+grl <- eisaR::getFeatureRanges(
+  gtf = gtf,
+  featureType = c("spliced", "intron"), 
+  intronType = "separate", 
+  flankLength = 90L, 
+  joinOverlappingIntrons = FALSE,
+  verbose = TRUE
+)
+#grl[4:6]
+
+# load in primary genome
+genome <- Biostrings::readDNAStringSet(opt$genome)
+head(genome)
+names(genome) <- sapply(strsplit(names(genome), " "), .subset, 1)
+
+# extract sequences for features of interest based on spliced and intronic
+# genomic regions defined above
+seqs <- GenomicFeatures::extractTranscriptSeqs(
+  x = genome, 
+  transcripts = grl
+)
+
+# write regions of interest to fasta file
+Biostrings::writeXStringSet(
+  seqs, filepath = expanded_fasta
+)
+
+# write the associated annotations to gtf 
+eisaR::exportToGtf(
+  grl, 
+  filepath = expanded_gtf
+)
+
+# create text file mapping transcript and intron identifiers to 
+# corresponding gene identifiers
+df <- eisaR::getTx2Gene(
+  grl, filepath = expanded_tx2gene
+)


### PR DESCRIPTION
Similar to #52, the cellranger workflow also needed to be updated to run with any of the 10x technologies (v2, v3, or v3.1). This is now included in the workflow. 

Additionally, there was an error in the `getCRsamples` function that threw an indexing error if the folders where the fastq files lived also contained index files. To go around this, the regular expression has been altered to find the sample names from both the R1/R2 fastqs or index fastqs. 