### PR TITLE
Update cellranger to allow flexibility for all 10x technology

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,5 +54,5 @@ workflows/*/data/
 # Ignore cellranger download
 images/cellranger/cellranger*.tar.gz
 
-
-
+# Ignore nextflow logs
+workflows/nextflow_logs/

--- a/workflows/cellranger-quant/run-cellranger.nf
+++ b/workflows/cellranger-quant/run-cellranger.nf
@@ -13,7 +13,7 @@ params.run_ids = "SCPCR000001,SCPCR000002"
 params.outdir = 's3://nextflow-ccdl-results/scpca/cellranger-quant'
 
 // technology options
-technology = ["10Xv2", "10Xv3", "10Xv3.1"]
+tech_list = ["10Xv2", "10Xv3", "10Xv3.1"]
 
 // build full paths
 params.index_path = "${params.ref_dir}/${params.index_dir}/${params.index_name}"

--- a/workflows/cellranger-quant/run-cellranger.nf
+++ b/workflows/cellranger-quant/run-cellranger.nf
@@ -50,7 +50,7 @@ def getCRsamples(filelist){
   fastq_files.each{
     // append sample names to list, using regex to extract element before S001, etc.
     // [0] for the first match set, [1] for the first extracted element
-    samples << (it =~ /^(.+)_S.+_L.+_R.+.fastq.gz$/)[0][1]
+    samples << (it =~ /^(.+)_S.+_L.+_[R|I].+.fastq.gz$/)[0][1]
   }
   // convert samples list to a `set` to remove duplicate entries,
   // then join to a comma separated string.
@@ -63,7 +63,7 @@ workflow{
   run_all = run_ids[0] == "All"
   ch_reads = Channel.fromPath(params.run_metafile)
     .splitCsv(header: true, sep: '\t')
-    .filter{it.technology == "10Xv3"} // only 10X data
+    .filter{it.technology in technology} // only 10X data
     // use only the rows in the sample list
     .filter{run_all || (it.scpca_run_id in run_ids)}
     // create tuple of [sample_id, sample_names, fastq dir]

--- a/workflows/cellranger-quant/run-cellranger.nf
+++ b/workflows/cellranger-quant/run-cellranger.nf
@@ -63,7 +63,7 @@ workflow{
   run_all = run_ids[0] == "All"
   ch_reads = Channel.fromPath(params.run_metafile)
     .splitCsv(header: true, sep: '\t')
-    .filter{it.technology in technology} // only 10X data
+    .filter{it.technology in tech_list} // only 10X data
     // use only the rows in the sample list
     .filter{run_all || (it.scpca_run_id in run_ids)}
     // create tuple of [sample_id, sample_names, fastq dir]

--- a/workflows/cellranger-quant/run-cellranger.nf
+++ b/workflows/cellranger-quant/run-cellranger.nf
@@ -12,6 +12,9 @@ params.run_metafile = 's3://ccdl-scpca-data/sample_info/scpca-library-metadata.t
 params.run_ids = "SCPCR000001,SCPCR000002"
 params.outdir = 's3://nextflow-ccdl-results/scpca/cellranger-quant'
 
+// technology options
+technology = ["10Xv2", "10Xv3", "10Xv3.1"]
+
 // build full paths
 params.index_path = "${params.ref_dir}/${params.index_dir}/${params.index_name}"
 


### PR DESCRIPTION
Similar to #52, the cellranger workflow also needed to be updated to run with any of the 10x technologies (v2, v3, or v3.1). This is now included in the workflow.

Additionally, there was an error in the getCRsamples function that threw an indexing error if the folders where the fastq files lived also contained index files. To go around this, the regular expression has been altered to find the sample names from both the R1/R2 fastqs or index fastqs.