### PR TITLE
Modify index building workflows to include pre mRNA index 

### DIFF
--- a/workflows/rnaseq-ref-index/build-index.nf
+++ b/workflows/rnaseq-ref-index/build-index.nf
@@ -3,7 +3,6 @@ nextflow.enable.dsl=2
 
 // basic parameters
 params.ref_dir = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-103'
-params.cdna = 'fasta/Homo_sapiens.GRCh38.cdna.all.fa.gz'
 params.spliced_txome = 'fasta/Homo_sapiens.GRCh38.103.spliced.txome.fa.gz'
 params.spliced_intron_txome = 'fasta/Homo_sapiens.GRCh38.103.spliced_intron.txome.fa.gz'
 params.ensembl_txome = 'fasta/Homo_sapiens.GRCh38.txome.fa.gz'
@@ -39,7 +38,6 @@ process salmon_index_no_sa{
       -i ${index_base}_k${kmer} \
       -k ${kmer} \
       -p ${task.cpus} \
-      --gencode
     """
 }
 
@@ -68,7 +66,6 @@ process salmon_index_full_sa{
       -i ${index_base}_k${kmer}_full_sa \
       -k ${kmer} \
       -p ${task.cpus} \
-      --gencode
     """
 }
 
@@ -95,8 +92,7 @@ process kallisto_index{
 workflow {
   // channel of the reference files and labels
   ch_ref = Channel
-    .fromList([["cdna", params.ref_dir + "/" + params.cdna, params.kmer],
-               ["ensembl_txome", params.ref_dir + "/" + params.ensembl_txome, params.kmer],
+    .fromList([["ensembl_txome", params.ref_dir + "/" + params.ensembl_txome, params.kmer],
                ["spliced_txome", params.ref_dir + "/" + params.spliced_txome, params.kmer],
                ["spliced_intron_txome", params.ref_dir + "/" + params.spliced_intron_txome, params.kmer]])
 

--- a/workflows/rnaseq-ref-index/build-index.nf
+++ b/workflows/rnaseq-ref-index/build-index.nf
@@ -24,6 +24,7 @@ def get_base(file){
 process salmon_index_no_sa{
   container 'quay.io/biocontainers/salmon:1.4.0--hf69c8f4_0'
   publishDir "${params.ref_dir}/salmon_index", mode: 'copy'
+  memory { 28.GB * task.attempt}
   cpus 8
   errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
   maxRetries 1
@@ -74,7 +75,10 @@ process salmon_index_full_sa{
 process kallisto_index{
   container 'quay.io/biocontainers/kallisto:0.46.2--h4f7b962_1'
   publishDir "${params.ref_dir}/kallisto_index", mode: 'copy'
-  memory 32.GB
+  memory { 120.GB * task.attempt}
+  cpus 8
+  errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
+  maxRetries 1
   input:
     tuple val(index_base), path(reference), val(kmer)
   output:


### PR DESCRIPTION
In this PR, I am altering the current `build-index.nf` workflow to build salmon and kallisto indexes using both the `spliced.txome.fa` and the `spliced_intron.txome.fa` that were generated in #68. Additionally, I updated all of the index's to now use the ensembl-103 build and the salmon index to use the container with the most recent salmon release (also used in the `alevin-quant/run-alevin.nf` workflow). 

One thing to note is that generating the index using the `spliced_intron.txome.fa` takes considerably more memory, and that has also now been adjusted so the workflow runs successfully. 