### PR TITLE
Add --include-introns for cellranger workflow

### DIFF
--- a/workflows/cellranger-quant/run-cellranger.nf
+++ b/workflows/cellranger-quant/run-cellranger.nf
@@ -11,11 +11,10 @@ params.run_metafile = 's3://ccdl-scpca-data/sample_info/scpca-library-metadata.t
 // or "All" to process all samples in the metadata file
 params.run_ids = "SCPCR000001,SCPCR000002"
 params.outdir = 's3://nextflow-ccdl-results/scpca/cellranger-quant'
+params.include_introns = false // use --include-introns to align to pre mRNA index
 
 // technology options
 tech_list = ["10Xv2", "10Xv3", "10Xv3.1"]
-
-params.include_introns = false 
 
 // build full paths
 params.index_path = "${params.ref_dir}/${params.index_dir}/${params.index_name}"

--- a/workflows/cellranger-quant/run-cellranger.nf
+++ b/workflows/cellranger-quant/run-cellranger.nf
@@ -15,6 +15,8 @@ params.outdir = 's3://nextflow-ccdl-results/scpca/cellranger-quant'
 // technology options
 tech_list = ["10Xv2", "10Xv3", "10Xv3.1"]
 
+params.include_introns = false 
+
 // build full paths
 params.index_path = "${params.ref_dir}/${params.index_dir}/${params.index_name}"
 
@@ -29,7 +31,7 @@ process cellranger{
   output:
     path output_id
   script:
-    output_id = "${id}-${index}"
+    output_id = "${id}-${index}-${params.include_introns ? '--include-introns' : 'pre_mRNA'}"
     """
     cellranger count \
       --id=${output_id} \
@@ -37,7 +39,9 @@ process cellranger{
       --fastqs=${fastq_dir} \
       --sample=${samples} \
       --localcores=${task.cpus} \
-      --localmem=${task.memory.toGiga()}
+      --localmem=${task.memory.toGiga()} \
+      ${params.include_introns ? '--include-introns' : ''}
+
     """
 }
 


### PR DESCRIPTION
Closes #72. I added a parameter to the run-cellranger.nf workflow to allow for flexibility to use cellranger with snRNA-seq samples. To use the --include-introns flag you would implement it at the time of running the workflow by executing: 

`nextflow run cellranger-quant/run-cellranger.nf --include_introns:"--include-introns"`

I don't think this is a permanent fix for this. Before we run all of our samples I think a better solution might be to grab the `seq-unit` from the `scpca-library-metadata.tsv` file and based on if the `seq-unit == nucleus`, then we would use the flag for `--include-introns`. 

However, since we are still in the benchmarking phase, I thought it might not be the best approach to give up complete control. It could be useful to compare some of the snRNA-seq runs using cellranger with and without this flag rather than include it as a default immediately. 