### PR TITLE
Fixed a minor error in where the mito gene list is output in the reference fasta script 

### DIFF
--- a/workflows/rnaseq-ref-index/make_pre_mrna_fasta.R
+++ b/workflows/rnaseq-ref-index/make_pre_mrna_fasta.R
@@ -165,4 +165,4 @@ gtf <- rtracklayer::import(txome_gtf)
 mitogenes <- gtf[seqnames(gtf) == 'MT']
 
 # write out mitochondrial gene list
-writeLines(mitogenes$gene_id, mito_file)
+writeLines(mitogenes$gene_id, mito_out)


### PR DESCRIPTION
In working through some of the benchmarking analysis, I realized that the mitogenes.txt file that is made in the new `make_pre_mrna_fasta.R` script wasn't output to the annotation folder like it should have been so was never synced to S3. I made the minor fix and then re-synced to S3 so it should be there. 