### PR TITLE
Adjust default index references for workflows

### DIFF
--- a/workflows/alevin-quant/run-alevin-fry.nf
+++ b/workflows/alevin-quant/run-alevin-fry.nf
@@ -2,12 +2,12 @@
 nextflow.enable.dsl=2
 
 // run parameters
-params.ref_dir = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-100'
+params.ref_dir = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-103'
 params.index_dir = 'salmon_index'
-params.index_name = 'txome_k31'
+params.index_name = 'spliced_txome_k31'
 params.annotation_dir = 'annotation'
-params.t2g = 'Homo_sapiens.ensembl.100.tx2gene.tsv'
-params.mitolist = 'Homo_sapiens.ensembl.100.mitogenes.txt'
+params.t2g = 'Homo_sapiens.GRCh38.103.spliced.tx2gene.tsv'
+params.mitolist = 'Homo_sapiens.GRCh38.103.mitogenes.txt'
 params.sketch = false // use sketch mode for mapping with flag `--sketch`
 
 params.run_metafile = 's3://ccdl-scpca-data/sample_info/scpca-library-metadata.tsv'

--- a/workflows/alevin-quant/run-alevin.nf
+++ b/workflows/alevin-quant/run-alevin.nf
@@ -2,12 +2,12 @@
 nextflow.enable.dsl=2
 
 // run parameters
-params.ref_dir = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-100'
+params.ref_dir = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-103'
 params.index_dir = 'salmon_index'
-params.index_name = 'txome_k31_full_sa'
+params.index_name = 'spliced_txome_k31_full_sa'
 params.annotation_dir = 'annotation'
-params.t2g = 'Homo_sapiens.ensembl.100.tx2gene.tsv'
-params.mitolist = 'Homo_sapiens.ensembl.100.mitogenes.txt'
+params.t2g = 'Homo_sapiens.GRCh38.103.spliced.tx2gene.tsv'
+params.mitolist = 'Homo_sapiens.GRCh38.103.mitogenes.txt'
 
 params.run_metafile = 's3://ccdl-scpca-data/sample_info/scpca-library-metadata.tsv'
 // run_ids are comma separated list to be parsed into a list of run ids,

--- a/workflows/kallisto-quant/run-kallisto.nf
+++ b/workflows/kallisto-quant/run-kallisto.nf
@@ -26,10 +26,11 @@ params.mito_path = "${params.ref_dir}/${params.annotation_dir}/${params.mitolist
 process kallisto_bus{
   container 'quay.io/biocontainers/kallisto:0.46.2--h4f7b962_1'
   label 'bigdisk'
-  label 'bigmem'
+  memory { sequnit == 'nucleus' ? '120.GB' : '28.GB'}
+  cpus 8
   tag "${id}-${index}"
   input:
-    tuple val(id), val(tech), path(read1), path(read2)
+    tuple val(id), val(tech), path(read1), path(read2), val(sequnit)
     path index
   output:
     path run_dir
@@ -133,7 +134,8 @@ workflow{
     .map{row -> tuple(row.scpca_run_id,
                       row.technology,
                       file("s3://${row.s3_prefix}/*_R1_*.fastq.gz"),
-                      file("s3://${row.s3_prefix}/*_R2_*.fastq.gz")
+                      file("s3://${row.s3_prefix}/*_R2_*.fastq.gz"),
+                      row.seq_unit
                       )}
   barcodes_ch = samples_ch
     .map{row -> file("${params.barcode_dir}/${barcodes[row.technology]}")}

--- a/workflows/kallisto-quant/run-kallisto.nf
+++ b/workflows/kallisto-quant/run-kallisto.nf
@@ -25,7 +25,8 @@ params.mito_path = "${params.ref_dir}/${params.annotation_dir}/${params.mitolist
 
 process kallisto_bus{
   container 'quay.io/biocontainers/kallisto:0.46.2--h4f7b962_1'
-  label 'bigdisk' 
+  label 'bigdisk'
+  label 'bigmem'
   tag "${id}-${index}"
   input:
     tuple val(id), val(tech), path(read1), path(read2)

--- a/workflows/kallisto-quant/run-kallisto.nf
+++ b/workflows/kallisto-quant/run-kallisto.nf
@@ -23,10 +23,9 @@ params.index_path = "${params.ref_dir}/${params.index_dir}/${params.index_name}"
 params.t2g_path = "${params.ref_dir}/${params.annotation_dir}/${params.t2g}"
 params.mito_path = "${params.ref_dir}/${params.annotation_dir}/${params.mitolist}"
 
-
 process kallisto_bus{
   container 'quay.io/biocontainers/kallisto:0.46.2--h4f7b962_1'
-  label 'cpus_8'
+  label 'bigdisk' 
   tag "${id}-${index}"
   input:
     tuple val(id), val(tech), path(read1), path(read2)
@@ -77,7 +76,6 @@ process bustools_whitelist{
 process bustools_correct{
   container 'quay.io/biocontainers/bustools:0.40.0--h4f7b962_0'
   label 'cpus_8'
-  tag "${id}-${index}"
   publishDir "${params.outdir}"
   input:
     path run_dir
@@ -100,7 +98,6 @@ process bustools_correct{
 process bustools_count{
   container 'quay.io/biocontainers/bustools:0.40.0--h4f7b962_0'
   label 'cpus_8'
-  tag "${id}-${index}"
   publishDir "${params.outdir}"
   input:
     path run_dir
@@ -135,7 +132,7 @@ workflow{
     .map{row -> tuple(row.scpca_run_id,
                       row.technology,
                       file("s3://${row.s3_prefix}/*_R1_*.fastq.gz"),
-                      file("s3://${row.s3_prefix}/*_R2_*.fastq.gz"),
+                      file("s3://${row.s3_prefix}/*_R2_*.fastq.gz")
                       )}
   barcodes_ch = samples_ch
     .map{row -> file("${params.barcode_dir}/${barcodes[row.technology]}")}

--- a/workflows/kallisto-quant/run-kallisto.nf
+++ b/workflows/kallisto-quant/run-kallisto.nf
@@ -2,12 +2,12 @@
 nextflow.enable.dsl=2
 
 // run parameters
-params.ref_dir = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-100'
+params.ref_dir = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-103'
 params.index_dir = 'kallisto_index'
-params.index_name = 'txome_k31'
+params.index_name = 'spliced_txome_k31'
 params.annotation_dir = 'annotation'
-params.t2g = 'Homo_sapiens.ensembl.100.tx2gene.tsv'
-params.mitolist = 'Homo_sapiens.ensembl.100.mitogenes.txt'
+params.t2g = 'Homo_sapiens.GRCh38.103.spliced.tx2gene.tsv'
+params.mitolist = 'Homo_sapiens.GRCh38.103.mitogenes.txt'
 params.barcode_dir = 's3://nextflow-ccdl-data/reference/10X/barcodes' 
 // 10X barcode files
 barcodes = ['10Xv2': '737K-august-2016.txt',
@@ -77,6 +77,7 @@ process bustools_whitelist{
 process bustools_correct{
   container 'quay.io/biocontainers/bustools:0.40.0--h4f7b962_0'
   label 'cpus_8'
+  tag "${id}-${index}"
   publishDir "${params.outdir}"
   input:
     path run_dir
@@ -99,6 +100,7 @@ process bustools_correct{
 process bustools_count{
   container 'quay.io/biocontainers/bustools:0.40.0--h4f7b962_0'
   label 'cpus_8'
+  tag "${id}-${index}"
   publishDir "${params.outdir}"
   input:
     path run_dir

--- a/workflows/nextflow.config
+++ b/workflows/nextflow.config
@@ -22,6 +22,15 @@ profiles{
       }
       withLabel: bigdisk {
         queue = 'nextflow-batch-bigdisk-queue'
+        cpus = 8
+        memory = { 120.GB * task.attempt}
+        errorStrategy = {task.exitStatus in 137..140 ? 'retry' : 'terminate' }
+        maxRetries = 1
+      }
+      trace {
+        enabled = true
+        file = '$params.outdir/trace.txt'
+        fields = 'task_id,process,tag,cpus,disk,attempt,realtime,%cpu,%mem,rss,peak_rss'
       }
     }
   }

--- a/workflows/nextflow.config
+++ b/workflows/nextflow.config
@@ -23,12 +23,6 @@ profiles{
       withLabel: bigdisk {
         queue = 'nextflow-batch-bigdisk-queue'
       }
-      withLabel: bigmem {
-        cpus = 8
-        memory = { 120.GB * task.attempt}
-        errorStrategy = {task.exitStatus in 137..140 ? 'retry' : 'terminate' }
-        maxRetries = 1
-      }
     }
   }
 }

--- a/workflows/nextflow.config
+++ b/workflows/nextflow.config
@@ -22,15 +22,12 @@ profiles{
       }
       withLabel: bigdisk {
         queue = 'nextflow-batch-bigdisk-queue'
+      }
+      withLabel: bigmem {
         cpus = 8
         memory = { 120.GB * task.attempt}
         errorStrategy = {task.exitStatus in 137..140 ? 'retry' : 'terminate' }
         maxRetries = 1
-      }
-      trace {
-        enabled = true
-        file = '$params.outdir/trace.txt'
-        fields = 'task_id,process,tag,cpus,disk,attempt,realtime,%cpu,%mem,rss,peak_rss'
       }
     }
   }


### PR DESCRIPTION
I am updating the default index's for each of the workflows to be the `spliced_txome_k31` index that was generated from the spliced only cDNA fasta as in #68. Currently, in order to switch to use the `spliced_intron_txome_k31` you will need to do so at the command line by doing `nextflow run alevin-quant/run-alevin.nf --index_name spliced_intron_txome_k31`. I have also updated the default `t2gene.tsv` files to use the `Homo_sapiens.GRCh38.103.spliced.tx2gene.tsv` file. 

Additionally, while running the workflows with the snRNA-seq data, I noticed that they required more memory than previously. The pre-mRNA index generated by Kallisto, in particular, is 45 gb and requires ~ 100 gb of memory for the samples that I did test runs on. Otherwise it is unable to load the index and write the output files. I am using 120 gb of memory here to be safe. 

It appears that Alevin also requires slightly more memory than the 28 gb allotted by the cpus_8 label in the configuration file as well, but nowhere near the 100 gb that Kallisto requires. 

I did spend some time trying to assign individual labels based on the input variable so that we could only use the higher memory requirements for Kallisto with snRNA-seq samples only, but it appears that there is no way to use input variables as  label assignments... https://github.com/nextflow-io/nextflow/issues/894. There is one potential work around that I was able to find to maybe include a second configuration file based on an input parameter, but after some back and forth with that, I landed on leaving it as is for now. 

I am leaving this in draft stage right now, as I still need to change the references in alevin-fry and ensure that workflow runs as expected. 
