### PR TITLE
Updates to Alevin-fry workflow to include unfiltered permit list

### DIFF
--- a/images/alevinfry/Dockerfile
+++ b/images/alevinfry/Dockerfile
@@ -5,6 +5,6 @@ LABEL maintainer="ccdl@alexslemonade.org"
 RUN apt-get update && apt-get install -y procps
 
 # Install alevin-fry using bioconda
-RUN conda install -c bioconda alevin-fry 
+RUN conda install -c conda-forge -c bioconda alevin-fry=0.2.0
 
 WORKDIR /home

--- a/workflows/alevin-quant/run-alevin-fry.nf
+++ b/workflows/alevin-quant/run-alevin-fry.nf
@@ -9,6 +9,14 @@ params.annotation_dir = 'annotation'
 params.t2g = 'Homo_sapiens.GRCh38.103.spliced.tx2gene.tsv'
 params.mitolist = 'Homo_sapiens.GRCh38.103.mitogenes.txt'
 params.sketch = false // use sketch mode for mapping with flag `--sketch`
+params.resolution = 'full' //default resolution is full, can also use cr-like, cr-like-em, parsimony, and trivial
+
+params.barcode_dir = 's3://nextflow-ccdl-data/reference/10X/barcodes' 
+// 10X barcode files
+barcodes = ['10Xv2': '737K-august-2016.txt',
+            '10Xv3': '3M-february-2018.txt',
+            '10Xv3.1': '3M-february-2018.txt']
+params.unfiltered = false // use unfiltered list mode to include 10X barcode list with flat `--unfiltered`
 
 params.run_metafile = 's3://ccdl-scpca-data/sample_info/scpca-library-metadata.tsv'
 // run_ids are comma separated list to be parsed into a list of run ids,
@@ -39,7 +47,7 @@ process alevin{
     path run_dir
   script:
     // label the run directory by id, index, and mapping mode
-    run_dir = "${id}-${index}-${params.sketch ? 'sketch' : 'salign'}"
+    run_dir = "${id}-${index}-${params.sketch ? 'sketch' : 'salign'}-${params.unfiltered ? 'unfiltered' : 'knee'}"
     // choose flag by technology
     tech_flag = ['10Xv2': '--chromium',
                  '10Xv3': '--chromiumV3',
@@ -70,11 +78,19 @@ process generate_permit{
   publishDir "${params.outdir}"
   input:
     path run_dir
+    path barcode_file
   output:
     path run_dir
   script: 
-  // expected-ori either signifies no filtering of alignments 
-  // based on orientation, not sure if this is what we want? 
+    if(params.unfiltered == true)
+    """
+    alevin-fry generate-permit-list \
+      -i ${run_dir} \
+      --expected-ori fw \
+      -o ${run_dir} \
+      -u ${barcode_file}
+    """
+    else
     """
     alevin-fry generate-permit-list \
       -i ${run_dir} \
@@ -118,6 +134,7 @@ process quant_fry{
      --input-dir ${run_dir} \
      --tg-map ${tx2gene} \
      --output-dir ${run_dir} \
+     -r ${params.resolution} \
      -t ${task.cpus}
     """
 }
@@ -138,10 +155,13 @@ workflow{
                       file("s3://${row.s3_prefix}/*_R1_*.fastq.gz"),
                       file("s3://${row.s3_prefix}/*_R2_*.fastq.gz"),
                       )}
+
+  barcodes_ch = samples_ch
+    .map{row -> file("${params.barcode_dir}/${barcodes[row.technology]}")}
   // run Alevin
   alevin(reads_ch, params.index_path, params.t2g_path)
   // generate permit list from alignment 
-  generate_permit(alevin.out)
+  generate_permit(alevin.out, barcodes_ch)
   // collate RAD files 
   collate_fry(generate_permit.out)
   // create gene x cell matrix

--- a/workflows/alevin-quant/run-alevin-fry.nf
+++ b/workflows/alevin-quant/run-alevin-fry.nf
@@ -82,21 +82,13 @@ process generate_permit{
   output:
     path run_dir
   script: 
-    if(params.unfiltered == true)
+    
     """
     alevin-fry generate-permit-list \
       -i ${run_dir} \
       --expected-ori fw \
       -o ${run_dir} \
-      -u ${barcode_file}
-    """
-    else
-    """
-    alevin-fry generate-permit-list \
-      -i ${run_dir} \
-      --expected-ori fw \
-      -o ${run_dir} \
-      --knee-distance
+      ${params.unfiltered ? "-u ${barcode_file}" : '--knee-distance'}
     """
 }
 


### PR DESCRIPTION
Closes #83. In this PR, I updated Alevin-fry to use the new Alevin-fry 0.2.0, adding an option to use the unfiltered permit list of barcodes from 10x with the `-unfiltered-pl` argument during the generate-permit-list step. 

I first updated the docker image for Alevin-fry so it contains Alevin-fry:0.2.0 which can be pulled using `docker pull ghcr.io/alexslemonade/scpca-alevin-fry:latest`. In that update, there is a dependency on the most recent version of `libcxx`, requiring the install using the `-conda-forge` channel. 

I then added in the option to include the unfiltered barcode list from the 10X whitelist, which can be utilized by using the `--unfiltered` flag. When this option is used, the corresponding 10X barcode list for that sample is used, otherwise true cells are determined using the `--knee-distance` option. ~~I had tried to put the argument in a ternary operator and do something like ${params.unfiltered ? '-u' ${barcode_file} : '--knee-distance'} but nextflow doesn't like that. So I chose to do a conditional process based on the unfiltered parameter being true or not which works.~~

I also added in the resolution as a parameter. The default is set as full, but can be changed at the command line if we want to test other options. 