### PR TITLE
Update Cellranger for mkfastq

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ workflows/rnaseq-ref-index/fasta/
 workflows/*/data/
 
 # Ignore software downloads
+*.rpm
 images/cellranger/cellranger*.tar.gz
 images/cellranger/bcl2fastq*.tar.gz
 

--- a/.gitignore
+++ b/.gitignore
@@ -51,8 +51,11 @@ workflows/rnaseq-ref-index/annotation/
 workflows/rnaseq-ref-index/fasta/
 workflows/*/data/
 
-# Ignore cellranger download
+# Ignore software downloads
 images/cellranger/cellranger*.tar.gz
+images/cellranger/bcl2fastq*.tar.gz
 
 # Ignore nextflow logs
 workflows/nextflow_logs/
+
+

--- a/images/cellranger/Dockerfile
+++ b/images/cellranger/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 LABEL maintainer="ccdl@alexslemonade.org"
 
-RUN apt update && apt install -y build-essential libzip-dev
+RUN apt-get update && apt-get install -y build-essential libzip-dev
 
 # Install bcl2fastq
 WORKDIR /tmp

--- a/images/cellranger/Dockerfile
+++ b/images/cellranger/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:centos8
+FROM centos:centos7
 LABEL maintainer="ccdl@alexslemonade.org"
 
 RUN yum makecache && yum install -y unzip

--- a/images/cellranger/Dockerfile
+++ b/images/cellranger/Dockerfile
@@ -1,7 +1,5 @@
-FROM centos:centos7
+FROM centos:7
 LABEL maintainer="ccdl@alexslemonade.org"
-
-RUN yum makecache && yum install -y unzip
 
 # Install bcl2fastq
 WORKDIR /tmp

--- a/images/cellranger/Dockerfile
+++ b/images/cellranger/Dockerfile
@@ -1,9 +1,18 @@
 FROM ubuntu:20.04
 LABEL maintainer="ccdl@alexslemonade.org"
 
+RUN apt update && apt install -y build-essential libzip-dev
+
+# Install bcl2fastq
+WORKDIR /tmp
+COPY bcl2fastq2-v2.20.0.422-Source.tar.gz bcl2fastq2.tar.gz
+COPY install-bcl2fastq.sh install-bcl2fastq.sh
+RUN bash install-bcl2fastq.sh
+
+# Install cellranger
 WORKDIR /opt
-COPY cellranger-6.0.0.tar.gz cellranger-6.0.0.tar.gz
-RUN tar xzf cellranger-6.0.0.tar.gz && rm cellranger-6.0.0.tar.gz
-ENV PATH="/opt/cellranger-6.0.0:${PATH}"
+COPY cellranger-6.0.1.tar.gz cellranger-6.0.1.tar.gz
+RUN tar xzf cellranger-6.0.1.tar.gz && rm cellranger-6.0.1.tar.gz
+ENV PATH="/opt/cellranger-6.0.1:${PATH}"
 
 WORKDIR /home

--- a/images/cellranger/Dockerfile
+++ b/images/cellranger/Dockerfile
@@ -5,11 +5,9 @@ RUN yum makecache && yum install -y unzip
 
 # Install bcl2fastq
 WORKDIR /tmp
-COPY bcl2fastq2-v2-20-0-linux-x86-64.zip bcl2fastq2-v2-20-0-linux-x86-64.zip
-RUN unzip bcl2fastq2-v2-20-0-linux-x86-64.zip
-RUN rpm -i bcl2fastq2-v2.20.0.422-Linux-x86_64.rpm \
-&& rm bcl2fastq2-v2.20.0.422-Linux-x86_64.rpm && \
- rm bcl2fastq2-v2-20-0-linux-x86-64.zip
+COPY bcl2fastq2-v2.20.0.422-Linux-x86_64.rpm bcl2fastq2.rpm
+RUN rpm -i bcl2fastq2.rpm 
+
 # Install cellranger
 WORKDIR /opt
 COPY cellranger-6.0.1.tar.gz cellranger-6.0.1.tar.gz

--- a/images/cellranger/Dockerfile
+++ b/images/cellranger/Dockerfile
@@ -1,14 +1,15 @@
-FROM ubuntu:20.04
+FROM centos:centos8
 LABEL maintainer="ccdl@alexslemonade.org"
 
-RUN apt-get update && apt-get install -y build-essential libzip-dev
+RUN yum makecache && yum install -y unzip
 
 # Install bcl2fastq
 WORKDIR /tmp
-COPY bcl2fastq2-v2.20.0.422-Source.tar.gz bcl2fastq2.tar.gz
-COPY install-bcl2fastq.sh install-bcl2fastq.sh
-RUN bash install-bcl2fastq.sh
-
+COPY bcl2fastq2-v2-20-0-linux-x86-64.zip bcl2fastq2-v2-20-0-linux-x86-64.zip
+RUN unzip bcl2fastq2-v2-20-0-linux-x86-64.zip
+RUN rpm -i bcl2fastq2-v2.20.0.422-Linux-x86_64.rpm \
+&& rm bcl2fastq2-v2.20.0.422-Linux-x86_64.rpm && \
+ rm bcl2fastq2-v2-20-0-linux-x86-64.zip
 # Install cellranger
 WORKDIR /opt
 COPY cellranger-6.0.1.tar.gz cellranger-6.0.1.tar.gz

--- a/images/cellranger/README.md
+++ b/images/cellranger/README.md
@@ -6,9 +6,8 @@ This folder contains a Dockerfile for the cellranger analysis.
 In order to build this image, the cellranger software and bcl2fastq source code components must be downloaded separately to comply with licensing, and should be placed in this folder (`images/cellranger`).
 - The current version of cellranger is `cellranger-6.0.1.tar.gz` and can be downloaded from [10X Genomics Website](https://support.10xgenomics.com/single-cell-gene-expression/software/downloads/6.0) after agreeing to their license terms.
 - The current version of bcl2fastq is 2.20.0 and can be downloaded from [Illumina](https://support.illumina.com/sequencing/sequencing_software/bcl2fastq-conversion-software.html) after logging into an Illumina account.
-  - As we are using an Ubuntu image, you will need to download the "Linux tarball" version of the software.
-  - Note that the file Illumina provides to download is a `.tar.zip` file that should contain the `bcl2fastq2-v2.20.0.422-Source.tar.gz` file specified in the `Dockerfile`. 
-  - Use `tar xzf bcl2fastq2-v2-20-0-tar.zip` to unpack the redundant packaging.
+  - As we are using an Centos image, you will need to download the "Linux rpm" version of the software.
+  - Note that the file Illumina provides to download is a `.zip` file that should contain the `bcl2fastq2-v2.20.0.422-Linux-x86_64.rpm` file specified in the `Dockerfile`. 
 
 Following download of cellranger and bcl2fastq, you can build the image running the following command from this `images/cellranger` working directory:
 
@@ -49,4 +48,3 @@ docker tag scpca-cellranger:6.0.1 589864003899.dkr.ecr.us-east-1.amazonaws.com/s
 docker push 589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:6.0.1
 docker push 589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:latest
 ```
-

--- a/images/cellranger/README.md
+++ b/images/cellranger/README.md
@@ -5,8 +5,9 @@ This folder contains a Dockerfile for the cellranger analysis.
 
 In order to build this image, the cellranger software and bcl2fastq source code components must be downloaded separately to comply with licensing, and should be placed in this folder (`images/cellranger`).
 - The current version of cellranger is `cellranger-6.0.1.tar.gz` and can be downloaded from [10X Genomics Website](https://support.10xgenomics.com/single-cell-gene-expression/software/downloads/6.0) after agreeing to their license terms.
-- The current version of bcl2fastq is 2.20.0  and can be downloaded from [Illumina](https://support.illumina.com/sequencing/sequencing_software/bcl2fastq-conversion-software.html) after logging into an Illumina account.
-  - Note that the file you download is a `.tar.zip` file that should contain the `bcl2fastq2-v2.20.0.422-Source.tar.gz` file specified in the `Dockerfile`. 
+- The current version of bcl2fastq is 2.20.0 and can be downloaded from [Illumina](https://support.illumina.com/sequencing/sequencing_software/bcl2fastq-conversion-software.html) after logging into an Illumina account.
+  - As we are using an Ubuntu image, you will need to download the "Linux tarball" version of the software.
+  - Note that the file Illumina provides to download is a `.tar.zip` file that should contain the `bcl2fastq2-v2.20.0.422-Source.tar.gz` file specified in the `Dockerfile`. 
   - Use `tar xzf bcl2fastq2-v2-20-0-tar.zip` to unpack the redundant packaging.
 
 Following download of cellranger and bcl2fastq, you can build the image running the following command from this `images/cellranger` working directory:

--- a/images/cellranger/README.md
+++ b/images/cellranger/README.md
@@ -3,13 +3,16 @@ This folder contains a Dockerfile for the cellranger analysis.
 
 ## Building the image
 
-In order to build this image, the cellranger archive component must be downloaded separately to comply with licensing, and should be placed in this folder (`images/cellranger`).
-The current version of this file is `cellranger-6.0.0.tar.gz` and can be downloaded from [10X Genomics Website](https://support.10xgenomics.com/single-cell-gene-expression/software/downloads/6.0) after agreeing to their license terms.
+In order to build this image, the cellranger software and bcl2fastq source code components must be downloaded separately to comply with licensing, and should be placed in this folder (`images/cellranger`).
+- The current version of cellranger is `cellranger-6.0.1.tar.gz` and can be downloaded from [10X Genomics Website](https://support.10xgenomics.com/single-cell-gene-expression/software/downloads/6.0) after agreeing to their license terms.
+- The current version of bcl2fastq is 2.20.0  and can be downloaded from [Illumina](https://support.illumina.com/sequencing/sequencing_software/bcl2fastq-conversion-software.html) after logging into an Illumina account.
+  - Note that the file you download is a `.tar.zip` file that should contain the `bcl2fastq2-v2.20.0.422-Source.tar.gz` file specified in the `Dockerfile`. 
+  - Use `tar xzf bcl2fastq2-v2-20-0-tar.zip` to unpack the redundant packaging.
 
-Following download of cellranger, you can build the image running the following command from this `images/cellranger` working directory:
+Following download of cellranger and bcl2fastq, you can build the image running the following command from this `images/cellranger` working directory:
 
 ```
-docker build . -t scpca-cellranger:6.0.0
+docker build . -t scpca-cellranger:6.0.1
 ```
 
 At this point, the image should be ready for use on the local machine.
@@ -40,9 +43,9 @@ If the updated image needs to be pushed to AWS ECR, you can follow the outline s
 The current image was pushed with the following commands.
 
 ```
-docker tag scpca-cellranger:6.0.0 589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:latest
-docker tag scpca-cellranger:6.0.0 589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:6.0.0
-docker push 589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:6.0.0
+docker tag scpca-cellranger:6.0.1 589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:latest
+docker tag scpca-cellranger:6.0.1 589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:6.0.1
+docker push 589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:6.0.1
 docker push 589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:latest
 ```
 

--- a/images/cellranger/install-bcl2fastq.sh
+++ b/images/cellranger/install-bcl2fastq.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euo pipefail
+
+# Install bcl2fastq per illumina docs
+BASE=${PWD}
+SOURCE=${BASE}/bcl2fastq
+BUILD=${BASE}/bcl2fastq2-build 
+INSTALL_DIR=/usr/local
+
+# cmake won't find libraries without this
+export C_INCLUDE_PATH=/usr/include/x86_64-linux-gnu
+
+tar -xzf bcl2fastq2.tar.gz
+
+mkdir -p ${BUILD}
+cd ${BUILD}
+chmod ugo+x ${SOURCE}/src/configure
+chmod ugo+x ${SOURCE}/src/cmake/bootstrap/installCmake.sh 
+${SOURCE}/src/configure --prefix=${INSTALL_DIR}
+
+cd ${BUILD}
+make
+make install
+
+
+# clean up
+cd ${BASE}
+rm -rf ${SOURCE}
+rm -rf ${BUILD}


### PR DESCRIPTION
This PR updates the cellranger Dockerfile to also build bcl2fastq so that `cellranger mkfastq` can be run.

In order to build this, you now need to download bcl2fastq from Illumina as well as Cellranger, but I have not yet updated the documentation to reflect this fact, hence the draft status.