### PR TITLE
Update alevin-fry docker to 0.3.0

### DIFF
--- a/images/alevinfry/Dockerfile
+++ b/images/alevinfry/Dockerfile
@@ -5,6 +5,6 @@ LABEL maintainer="ccdl@alexslemonade.org"
 RUN apt-get update && apt-get install -y procps
 
 # Install alevin-fry using bioconda
-RUN conda install -c conda-forge -c bioconda alevin-fry=0.2.0
+RUN conda install -c conda-forge -c bioconda alevin-fry=0.3.0
 
 WORKDIR /home


### PR DESCRIPTION
In starting to run samples with the `splici` index and narrow in on testing alevin-fry, it was necessary to update the current docker image to alevin-fry 0.3.0. The new image has now been built and pushed to the git hub repository and can be pulled using `docker pull ghcr.io/alexslemonade/scpca-alevin-fry:0.3.0` or `docker pull ghcr.io/alexslemonade/scpca-alevin-fry:latest`. 