### PR TITLE
Update reference scripts to make splici.fa

### DIFF
--- a/analysis/reference-file-comparisons/compare_spliced_ensembl.Rmd
+++ b/analysis/reference-file-comparisons/compare_spliced_ensembl.Rmd
@@ -66,7 +66,6 @@ ensembl_fasta <- file.path(ref_dir, "fasta", "Homo_sapiens.GRCh38.txome.fa.gz")
 
 spliced_txome <- Biostrings::readDNAStringSet(spliced_fasta)
 ensembl_txome <- Biostrings::readDNAStringSet(ensembl_fasta)
-
 ```
 
 How long is each?
@@ -162,6 +161,43 @@ missing_tx_info %>%
 It certainly seems to be.
 
 Should we add the non-primary assembly to our references, or are we okay with these differences?
+
+
+## Splici vs. Spliced_Intron Fasta
+In generating the splici index, there is a step to obtain unique sequences only before writing the sequences to the fasta. 
+This results in the size of the splici.fa being much smaller than the spliced_intron.fa, suggesting that they are different and that the spliced_intron.fa contains duplicated sequences.
+
+```{r}
+# look at splici vs. spliced_intron fasta
+splici_fasta <- file.path(ref_dir, "fasta", "Homo_sapiens.GRCh38.103.splici.fa.gz")
+spliced_intron_fasta <- file.path(ref_dir, "fasta", "Homo_sapiens.GRCh38.103.spliced_intron.txome.fa.gz")
+
+splici_txome <- Biostrings::readDNAStringSet(splici_fasta)
+spliced_intron_txome <- Biostrings::readDNAStringSet(spliced_intron_fasta)
+```
+
+```{r}
+# get transcript ID's
+splici_fa_txs <- stringr::word(names(splici_txome),1)
+spliced_intron_fa_txs <- stringr::word(names(spliced_intron_txome),1)
+```
+
+```{r}
+# how many of the spliced_intron transcript ID's are unique? 
+unique_spliced_intron <- unique(spliced_intron_fa_txs)
+
+# what's the intersect between the spliced_intron and splici transcript ID's? 
+shared_splici_fa_tx <- intersect(splici_fa_txs, spliced_intron_fa_txs)
+
+glue::glue("
+  The splici transcriptome has: {length(unique_spliced_intron)} unique transcript IDs.
+  The splici transcriptome and spliced_intron transcriptome have: {length(shared_splici_fa_tx)} shared transcript IDs.
+  ")
+```
+
+
+This tells me that the spliced_intron.fasta contains duplicated sequences that map to multiple transcript ID's. 
+How 
 
 ## Session info
 

--- a/analysis/reference-file-comparisons/compare_spliced_ensembl.Rmd
+++ b/analysis/reference-file-comparisons/compare_spliced_ensembl.Rmd
@@ -178,8 +178,8 @@ spliced_intron_txome <- Biostrings::readDNAStringSet(spliced_intron_fasta)
 
 ```{r}
 # get transcript ID's
-splici_fa_txs <- stringr::word(names(splici_txome),1)
-spliced_intron_fa_txs <- stringr::word(names(spliced_intron_txome),1)
+splici_fa_txs <- names(splici_txome)
+spliced_intron_fa_txs <- names(spliced_intron_txome)
 ```
 
 ```{r}
@@ -194,10 +194,9 @@ glue::glue("
   The splici transcriptome and spliced_intron transcriptome have: {length(shared_splici_fa_tx)} shared transcript IDs.
   ")
 ```
+This tells us that the spliced_intron.fasta contains duplicated sequences that map to multiple transcript ID's. 
+This could likely be causing a problem for tools that throw out multi-mapping reads. 
 
-
-This tells me that the spliced_intron.fasta contains duplicated sequences that map to multiple transcript ID's. 
-How 
 
 ## Session info
 

--- a/workflows/rnaseq-ref-index/make_pre_mrna_fasta.R
+++ b/workflows/rnaseq-ref-index/make_pre_mrna_fasta.R
@@ -155,7 +155,7 @@ splici_tx2gene_df_3col <- splici_tx2gene_df  %>%
   # remove extra -I* on gene ID
   mutate(gene_id = stringr::word(gene_id,1,sep = '-'),
          #if transcript_id contains an added -I*, then it is usnpliced
-         status = ifelse(stringr::str_detect(transcript_id, '-'), 'U', 'S'))
+         status = ifelse(stringr::str_detect(transcript_id, '-I'), 'U', 'S'))
 
 # write 3 column tx2gene
 readr::write_tsv(splici_tx2gene_df_3col, spliced_intron_tx2gene_3col, col_names = FALSE)

--- a/workflows/rnaseq-ref-index/make_pre_mrna_fasta.R
+++ b/workflows/rnaseq-ref-index/make_pre_mrna_fasta.R
@@ -133,7 +133,7 @@ splici_grl <- splici_grl[names(splici_seqs)]
 
 # write splici to fasta 
 Biostrings::writeXStringSet(
-  splici_seqs, filepath = splici_fasta, compress = TRUE
+  splici_seqs, filepath = spliced_intron_fasta, compress = TRUE
 )
 
 # write the associated annotations to gtf 

--- a/workflows/rnaseq-ref-index/make_pre_mrna_fasta.R
+++ b/workflows/rnaseq-ref-index/make_pre_mrna_fasta.R
@@ -144,11 +144,6 @@ eisaR::exportToGtf(
 
 # create text file mapping transcript and intron identifiers to corresponding gene identifiers
 # make 2 column Tx2Gene for all spliced and intron sequences
-full_tx2gene <- eisaR::getTx2Gene(
-  grl, filepath = spliced_intron_tx2gene
-)
-
-# make Tx2 gene needed for alevin-fry USA mode
 splici_tx2gene_df <- eisaR::getTx2Gene(splici_grl)
 
 # write out 2 column Tx2 gene mapping

--- a/workflows/rnaseq-ref-index/make_pre_mrna_fasta.R
+++ b/workflows/rnaseq-ref-index/make_pre_mrna_fasta.R
@@ -152,10 +152,10 @@ readr::write_tsv(splici_tx2gene_df, spliced_intron_tx2gene, col_names = FALSE)
 # make 3 column Tx2 gene needed for alevin-fry USA mode
 splici_tx2gene_df_3col <- splici_tx2gene_df  %>%
   # add status column
-  # if transcript_id contains an added -I, then it is usnpliced
-  mutate(status = ifelse(str_count(transcript_id, '-') > 0, 'U', 'S'),
-         # remove extra -I on gene ID
-         gene_id = str_extract(gene_id, "[^-]+"))
+  # remove extra -I* on gene ID
+  mutate(gene_id = stringr::word(gene_id,1,sep = '-'),
+         #if transcript_id contains an added -I*, then it is usnpliced
+         status = ifelse(stringr::str_detect(transcript_id, '-'), 'U', 'S'))
 
 # write 3 column tx2gene
 readr::write_tsv(splici_tx2gene_df_3col, spliced_intron_tx2gene_3col, col_names = FALSE)


### PR DESCRIPTION
To start addressing #95, we need to create the necessary fasta and tx2gene files for the `splici` index. I started by adding in just the addition of making the `tx2gene_3col.tsv` mapping that includes a third column containing information whether or not each transcript is categorized as spliced, unspliced, or ambiguous and then realized that the additional steps indicated in the [alevin-fry splici tutorial](https://combine-lab.github.io/alevin-fry-tutorials/2021/improving-txome-specificity/) altered the fasta output. Based on following the suggestions from the tutorial, they include a step to obtain unique sequences only before outputting the fasta. This was something we were not doing prior when creating our `spliced_intron.fa`. After looking at the output, it appears that about half of the sequences that are input into the `spliced_intron.fa` are duplicates and able to align to multiple transcripts. When looking at the sequences, they are duplicate, however the transcript ID's are unique. Additionally, all of the transcript ID's associated with duplicate reads are from intronic regions of transcripts. 

This could potentially be a problem when using the `spliced_intron.fa` with any of the tools that would throw out reads that are multi-mapping. Since we have decided to use this index with snRNA-seq samples with alevin-fry right now, this could impact how reads are assigned to each gene, as the full resolution is using an expectation maximization algorithm, while the `cr-like` mode assigns the read to the UMI with the highest count for that gene. However, it's unclear to me if we are losing sequences and potential information by adding this step. I reached out to Rob for some clarification and have not heard back yet. 

More information on alevin-fry quant can be found [here for reference](https://alevin-fry.readthedocs.io/en/latest/quant.html). 

Since we are interested in testing the `splici` index regardless, I went ahead and modified the scripts to generate the `splici.fa` in addition to the index files we already are generating. I added in a short comparison of the transcript ID's in the `compare_spliced_ensembl.Rmd` notebook we had, but think the real test is going to be does this alter the downstream results, which we will know after our next round of benchmarking. Happy to hear other thoughts on this! 