### PR TITLE
Adjust alevin to use splici index and USA mode

### DIFF
--- a/workflows/alevin-quant/run-alevin-fry.nf
+++ b/workflows/alevin-quant/run-alevin-fry.nf
@@ -32,7 +32,7 @@ barcodes = ['10Xv2': '737K-august-2016.txt',
             '10Xv3.1': '3M-february-2018.txt']
 
 // supported single cell technologies
-tech_list = ['10Xv2', '10Xv3', '10Xv3.1'] 
+tech_list = barcodes.keySet()
 
 // generates RAD file using alevin
 process alevin{

--- a/workflows/alevin-quant/run-alevin-fry.nf
+++ b/workflows/alevin-quant/run-alevin-fry.nf
@@ -23,6 +23,8 @@ barcodes = ['10Xv2': '737K-august-2016.txt',
             '10Xv3': '3M-february-2018.txt',
             '10Xv3.1': '3M-february-2018.txt']
 
+params.filter = 'unfiltered' // default filtering strategy is to use unfiltered, other options include --knee-distance
+
 params.run_metafile = 's3://ccdl-scpca-data/sample_info/scpca-library-metadata.tsv'
 // run_ids are comma separated list to be parsed into a list of run ids,
 // or "All" to process all samples in the metadata file
@@ -53,7 +55,7 @@ process alevin{
     path run_dir
   script:
     // label the run directory by id, index, and mapping mode
-    run_dir = "${id}-${index}-${params.sketch ? 'sketch' : 'salign'}-${params.resolution}"
+    run_dir = "${id}-${index}-${params.sketch ? 'sketch' : 'salign'}-${params.resolution}-${params.filter == 'knee' ? 'knee' : ''"}
     // choose flag by technology
     tech_flag = ['10Xv2': '--chromium',
                  '10Xv3': '--chromiumV3',
@@ -94,7 +96,7 @@ process generate_permit{
       -i ${run_dir} \
       --expected-ori fw \
       -o ${run_dir} \
-      -u ${barcode_file}
+      ${params.filter == 'knee' ? '--knee-distance' :  "-u ${barcode_file}"}
     """
 }
 

--- a/workflows/alevin-quant/run-alevin-fry.nf
+++ b/workflows/alevin-quant/run-alevin-fry.nf
@@ -10,10 +10,12 @@ params.sketch = false // use sketch mode for mapping with flag `--sketch`
 params.resolution = 'full' //default resolution is full, can also use cr-like, cr-like-em, parsimony, and trivial
 
 index_names_map = ['cell': 'spliced_txome_k31',
-                   'nucleus': 'spliced_intron_txome_k31']
+                   'splici': 'spliced_intron_txome_k31']
 
 t2g_map = ['cell': 'Homo_sapiens.GRCh38.103.spliced.tx2gene.tsv',
-       'nucleus': 'Homo_sapiens.GRCh38.103.spliced_intron.tx2gene.tsv']
+       'splici': 'Homo_sapiens.GRCh38.103.spliced_intron.tx2gene.tsv']
+
+params.t2g_3col = 'Homo_sapiens.GRCh38.103.spliced_intron.tx2gene_3col.tsv'
 
 params.barcode_dir = 's3://nextflow-ccdl-data/reference/10X/barcodes' 
 // 10X barcode files
@@ -31,6 +33,8 @@ params.outdir = 's3://nextflow-ccdl-results/scpca/alevin-fry-unfiltered-quant'
 // build full paths
 params.index_path = "${params.ref_dir}/${params.index_dir}/${index_names_map[params.index_type]}"
 params.t2g_path = "${params.ref_dir}/${params.annotation_dir}/${t2g_map[params.index_type]}"
+params.t2g_3col_path = 
+"${params.ref_dir}/${params.annotation_dir}/${params.resolution == 'cr-like' && params.index_type == 'splici' ? params.t2g_3col : t2g_map[params.index_type]}"
 
 // supported single cell technologies
 tech_list = ['10Xv2', '10Xv3', '10Xv3.1'] 
@@ -160,5 +164,5 @@ workflow{
   // collate RAD files 
   collate_fry(generate_permit.out)
   // create gene x cell matrix
-  quant_fry(collate_fry.out, params.t2g_path)
+  quant_fry(collate_fry.out, params.t2g_3col_path)
 }

--- a/workflows/alevin-quant/run-alevin-fry.nf
+++ b/workflows/alevin-quant/run-alevin-fry.nf
@@ -5,15 +5,15 @@ nextflow.enable.dsl=2
 params.ref_dir = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-103'
 params.index_dir = 'salmon_index'
 params.annotation_dir = 'annotation'
-params.index_type = 'cdna' // default index type is cdna
+params.index_type = 'cell' // default index type is cdna
 params.sketch = false // use sketch mode for mapping with flag `--sketch`
 params.resolution = 'full' //default resolution is full, can also use cr-like, cr-like-em, parsimony, and trivial
 
-index_names_map = ['cdna': 'spliced_txome_k31',
-                   'splici': 'spliced_intron_txome_k31']
+index_names_map = ['cell': 'spliced_txome_k31',
+                   'nucleus': 'spliced_intron_txome_k31']
 
-t2g_map = ['cdna': 'Homo_sapiens.GRCh38.103.spliced.tx2gene.tsv',
-       'splici': 'Homo_sapiens.GRCh38.103.spliced_intron.tx2gene.tsv']
+t2g_map = ['cell': 'Homo_sapiens.GRCh38.103.spliced.tx2gene.tsv',
+       'nucleus': 'Homo_sapiens.GRCh38.103.spliced_intron.tx2gene.tsv']
 
 params.barcode_dir = 's3://nextflow-ccdl-data/reference/10X/barcodes' 
 // 10X barcode files
@@ -37,7 +37,7 @@ tech_list = ['10Xv2', '10Xv3', '10Xv3.1']
 
 // generates RAD file using alevin
 process alevin{
-  container 'quay.io/biocontainers/salmon:1.4.0--h84f40af_1'
+  container 'quay.io/biocontainers/salmon:1.4.0--hf69c8f4_0'
   label 'cpus_8'
   tag "${id}-${index}"
   publishDir "${params.outdir}"

--- a/workflows/alevin-quant/run-alevin-fry.nf
+++ b/workflows/alevin-quant/run-alevin-fry.nf
@@ -5,38 +5,31 @@ nextflow.enable.dsl=2
 params.ref_dir = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-103'
 params.index_dir = 'salmon_index'
 params.annotation_dir = 'annotation'
-params.index_type = 'cell' // default index type is cdna
+params.index_type = 'cdna' // default index type is cdna, can also use splici
 params.sketch = false // use sketch mode for mapping with flag `--sketch`
 params.resolution = 'full' //default resolution is full, can also use cr-like, cr-like-em, parsimony, and trivial
+params.t2g_3col = 'Homo_sapiens.GRCh38.103.spliced_intron.tx2gene_3col.tsv'
+params.barcode_dir = 's3://nextflow-ccdl-data/reference/10X/barcodes' 
+params.filter = 'unfiltered' // default filtering strategy is to use unfiltered, other options include knee (--knee-distance)
+params.run_metafile = 's3://ccdl-scpca-data/sample_info/scpca-library-metadata.tsv'
+params.outdir = "s3://nextflow-ccdl-results/scpca/alevin-fry-${params.filter}-quant"
 
-index_names_map = ['cell': 'spliced_txome_k31',
+// run_ids are comma separated list to be parsed into a list of run ids,
+// or "All" to process all samples in the metadata file
+params.run_ids = "SCPCR000001,SCPCR000002"
+
+// index files 
+index_names_map = ['cdna': 'spliced_txome_k31',
                    'splici': 'spliced_intron_txome_k31']
 
-t2g_map = ['cell': 'Homo_sapiens.GRCh38.103.spliced.tx2gene.tsv',
-       'splici': 'Homo_sapiens.GRCh38.103.spliced_intron.tx2gene.tsv']
+// tx2gene files
+t2g_map = ['cdna': 'Homo_sapiens.GRCh38.103.spliced.tx2gene.tsv',
+           'splici': 'Homo_sapiens.GRCh38.103.spliced_intron.tx2gene.tsv']
 
-params.t2g_3col = 'Homo_sapiens.GRCh38.103.spliced_intron.tx2gene_3col.tsv'
-
-params.barcode_dir = 's3://nextflow-ccdl-data/reference/10X/barcodes' 
 // 10X barcode files
 barcodes = ['10Xv2': '737K-august-2016.txt',
             '10Xv3': '3M-february-2018.txt',
             '10Xv3.1': '3M-february-2018.txt']
-
-params.filter = 'unfiltered' // default filtering strategy is to use unfiltered, other options include --knee-distance
-
-params.run_metafile = 's3://ccdl-scpca-data/sample_info/scpca-library-metadata.tsv'
-// run_ids are comma separated list to be parsed into a list of run ids,
-// or "All" to process all samples in the metadata file
-params.run_ids = "SCPCR000001,SCPCR000002"
- 
-params.outdir = 's3://nextflow-ccdl-results/scpca/alevin-fry-unfiltered-quant'
-
-// build full paths
-params.index_path = "${params.ref_dir}/${params.index_dir}/${index_names_map[params.index_type]}"
-params.t2g_path = "${params.ref_dir}/${params.annotation_dir}/${t2g_map[params.index_type]}"
-params.t2g_3col_path = 
-"${params.ref_dir}/${params.annotation_dir}/${params.resolution == 'cr-like' && params.index_type == 'splici' ? params.t2g_3col : t2g_map[params.index_type]}"
 
 // supported single cell technologies
 tech_list = ['10Xv2', '10Xv3', '10Xv3.1'] 
@@ -55,7 +48,10 @@ process alevin{
     path run_dir
   script:
     // label the run directory by id, index, and mapping mode
-    run_dir = "${id}-${index}-${params.sketch ? 'sketch' : 'salign'}-${params.resolution}-${params.filter == 'knee' ? 'knee' : ''"}"
+    run_dir = "${id}-${index}-${params.sketch ? 'sketch' : 'salign'}-${params.resolution}"
+        if( params.filter != 'unfiltered'){
+          run_dir += "-${params.filter}"
+        }
     // choose flag by technology
     tech_flag = ['10Xv2': '--chromium',
                  '10Xv3': '--chromiumV3',
@@ -90,13 +86,14 @@ process generate_permit{
   output:
     path run_dir
   script: 
-    
+    filter_map = ['unfiltered' : "-u ${barcode_file}",
+                  'knee' : '--knee-distance']
     """
     alevin-fry generate-permit-list \
       -i ${run_dir} \
       --expected-ori fw \
       -o ${run_dir} \
-      ${params.filter == 'knee' ? '--knee-distance' :  "-u ${barcode_file}"}
+      ${filter_map[params.filter]}
     """
 }
 
@@ -159,12 +156,25 @@ workflow{
 
   barcodes_ch = samples_ch
     .map{row -> file("${params.barcode_dir}/${barcodes[row.technology]}")}
+  
+  // file paths
+  index_path = "${params.ref_dir}/${params.index_dir}/${index_names_map[params.index_type]}"
+  index_prefix = "${params.ref_dir}/${params.annotation_dir}"
+  t2g_path = "${index_prefix}/${t2g_map[params.index_type]}"
+  
+  // if using splici and cr-like use the 3 column t2g file for alevin-fry quant
+  if(params.resolution == 'cr-like' && params.index_type == 'splici'){
+      t2g_quant_path = "${index_prefix}/${params.t2g_3col}"
+  } else{
+      t2g_quant_path = t2g_path
+  }
+
   // run Alevin
-  alevin(reads_ch, params.index_path, params.t2g_path)
+  alevin(reads_ch, index_path, t2g_path)
   // generate permit list from alignment 
   generate_permit(alevin.out, barcodes_ch)
   // collate RAD files 
   collate_fry(generate_permit.out)
   // create gene x cell matrix
-  quant_fry(collate_fry.out, params.t2g_3col_path)
+  quant_fry(collate_fry.out, t2g_quant_path)
 }

--- a/workflows/alevin-quant/run-alevin-fry.nf
+++ b/workflows/alevin-quant/run-alevin-fry.nf
@@ -55,7 +55,7 @@ process alevin{
     path run_dir
   script:
     // label the run directory by id, index, and mapping mode
-    run_dir = "${id}-${index}-${params.sketch ? 'sketch' : 'salign'}-${params.resolution}-${params.filter == 'knee' ? 'knee' : ''"}
+    run_dir = "${id}-${index}-${params.sketch ? 'sketch' : 'salign'}-${params.resolution}-${params.filter == 'knee' ? 'knee' : ''"}"
     // choose flag by technology
     tech_flag = ['10Xv2': '--chromium',
                  '10Xv3': '--chromiumV3',

--- a/workflows/alevin-quant/run-alevin-fry.nf
+++ b/workflows/alevin-quant/run-alevin-fry.nf
@@ -11,6 +11,12 @@ params.mitolist = 'Homo_sapiens.GRCh38.103.mitogenes.txt'
 params.sketch = false // use sketch mode for mapping with flag `--sketch`
 params.resolution = 'full' //default resolution is full, can also use cr-like, cr-like-em, parsimony, and trivial
 
+//index_names = ['cell': 'spliced_txome_k31',
+//               'nucleus': 'spliced_intron_txome_k31']
+
+//t2g = ['cell': 'Homo_sapiens.GRCh38.103.spliced.tx2gene.tsv',
+//       'nucleus': 'Homo_sapiens.GRCh38.103.spliced_intron.tx2gene.tsv']
+
 params.barcode_dir = 's3://nextflow-ccdl-data/reference/10X/barcodes' 
 // 10X barcode files
 barcodes = ['10Xv2': '737K-august-2016.txt',


### PR DESCRIPTION
Closes #91. This PR changes some of the parameters in the alevin-fry and cellranger workflows being used for benchmarking. 

For alevin-fry, I have done the following: 
-  Combined the previous parameters for `index_name` and `t2g` to one `index_type` parameter to indicate if the workflow should be run using settings for the single-cell (`cell`) or single-nucleus (`splici`) samples. The default is set to `cell` and will then assign the `index_name` and corresponding tx2gene mapping file. 
- Added a parameter for the `tx2gene_3col.tsv` file needed to run Alevin-fry in USA mode. This can only be used if the `index_name` is set to `splici` and the resolution is `cr-like`. Otherwise, the 2 column tx2gene file is still used. 
- The unfiltered parameter has now been changed to `params.filter = unfiltered` as the default. If that is changed to `knee` then the `--knee-distance` flag is used to filter true barcodes during the `generate-permit-list step`. Based on our discussion of switching to only using the unfiltered version moving forward, I chose to set this as default and keep `knee` as an option just in case moving forward. 

Originally, I was planning on using the splici index as the default index for all single-nuclei RNA-seq samples, but with the addition of testing the splici index on single-cell samples that became less straight forward. Instead, I included a map of index_names and tx2gene files based on the index_type (currently set as `cell` or `splici`) with the anticipation that if we do choose to use an index for single-cell vs. single-nuclei, we can use the `seq_unit` column of the metadata to set the index and tx2gene (similar to how the barcode list is assigned now). 

For Cellranger, I set the default for single-nuclei samples to run with the pre-mRNA index using the `--include-introns` option, removing it as a parameter. 

I also did think about adding in checks to make sure the input parameters were correct, specifically the `params.filter` and the `params.resolution` options, but didn't think that was necessary quite yet. Probably something we want to consider adding if we do choose alevin-fry as our permanent workflow. 