### PR TITLE
Update docker image for Alevin-fry to v0.4.0

### DIFF
--- a/images/alevinfry/Dockerfile
+++ b/images/alevinfry/Dockerfile
@@ -5,6 +5,6 @@ LABEL maintainer="ccdl@alexslemonade.org"
 RUN apt-get update && apt-get install -y procps
 
 # Install alevin-fry using bioconda
-RUN conda install -c conda-forge -c bioconda alevin-fry=0.3.0
+RUN conda install -c conda-forge -c bioconda alevin-fry=0.4.0
 
 WORKDIR /home


### PR DESCRIPTION
Closes #103. This PR updates the Dockerfile for alevin-fry to build the image with the most current version, 0.4.0, of alevin-fry. I've tested that the image contains the correct version by running the image interactively and testing `alevin-fry --version`. 

I have also pushed this to github and tested that it can be pulled using: 
`docker pull ghcr.io/alexslemonade/scpca-alevin-fry:latest` or 
`docker pull ghcr.io/alexslemonade/scpca-alevin-fry:0.4.0`
