### PR TITLE
Update salmon to 1.5.2 and alevin-fry to 0.4.1

### DIFF
--- a/workflows/alevin-quant/run-alevin-fry.nf
+++ b/workflows/alevin-quant/run-alevin-fry.nf
@@ -89,7 +89,7 @@ process alevin{
 
 //generate permit list from RAD input 
 process generate_permit{
-  container 'quay.io/repository/biocontainers/alevin-fry:0.4.1--h7d875b9_0'
+  container 'quay.io/biocontainers/alevin-fry:0.4.1--h7d875b9_0'
   publishDir "${params.outdir}"
   input:
     path run_dir
@@ -110,7 +110,7 @@ process generate_permit{
 
 // given permit list and barcode mapping, collate RAD file 
 process collate_fry{
-  container 'quay.io/repository/biocontainers/alevin-fry:0.4.1--h7d875b9_0'
+  container 'quay.io/biocontainers/alevin-fry:0.4.1--h7d875b9_0'
   label 'cpus_8'
   publishDir "${params.outdir}"
   input: 
@@ -128,7 +128,7 @@ process collate_fry{
 
 // then quantify collated RAD file
 process quant_fry{
-  container 'quay.io/repository/biocontainers/alevin-fry:0.4.1--h7d875b9_0'
+  container 'quay.io/biocontainers/alevin-fry:0.4.1--h7d875b9_0'
   label 'cpus_8'
   publishDir "${params.outdir}"
   input: 

--- a/workflows/alevin-quant/run-alevin-fry.nf
+++ b/workflows/alevin-quant/run-alevin-fry.nf
@@ -22,7 +22,7 @@ params.run_ids = "SCPCR000001,SCPCR000002"
 index_names_map = ['cdna': 'spliced_txome_k31',
                    'splici': 'spliced_intron_txome_k31']
 
-// tx2gene files
+// tx2gene 2 column files
 t2g_map = ['cdna': 'Homo_sapiens.GRCh38.103.spliced.tx2gene.tsv',
            'splici': 'Homo_sapiens.GRCh38.103.spliced_intron.tx2gene.tsv']
 
@@ -37,14 +37,13 @@ tech_list = barcodes.keySet()
 // file paths
 index_path = "${params.ref_dir}/${params.index_dir}/${index_names_map[params.index_type]}"
 index_prefix = "${params.ref_dir}/${params.annotation_dir}"
-t2g_path = "${index_prefix}/${t2g_map[params.index_type]}"
   
 // if using splici and cr-like use the 3 column t2g file for alevin-fry quant
-if(params.resolution == 'cr-like' && params.index_type == 'splici'){
+if((params.resolution == 'cr-like' || params.resolution == 'cr-like-em') && params.index_type == 'splici'){
     t2g_quant_path = "${index_prefix}/${params.t2g_3col}"
     use_mtx = true
 } else{
-    t2g_quant_path = t2g_path
+    t2g_quant_path = "${index_prefix}/${t2g_map[params.index_type]}"
     use_mtx = false
 }
 

--- a/workflows/alevin-quant/run-alevin-fry.nf
+++ b/workflows/alevin-quant/run-alevin-fry.nf
@@ -18,6 +18,11 @@ params.outdir = "s3://nextflow-ccdl-results/scpca/alevin-fry-${params.filter}-qu
 // or "All" to process all samples in the metadata file
 params.run_ids = "SCPCR000001,SCPCR000002"
 
+// containers
+SALMON_CONTAINER = 'quay.io/biocontainers/salmon:1.5.2--h84f40af_0'
+ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.4.1--h7d875b9_0'
+
+
 // index files 
 index_names_map = ['cdna': 'spliced_txome_k31',
                    'splici': 'spliced_intron_txome_k31']
@@ -49,7 +54,7 @@ if((params.resolution == 'cr-like' || params.resolution == 'cr-like-em') && para
 
 // generates RAD file using alevin
 process alevin{
-  container 'quay.io/biocontainers/salmon:1.5.2--h84f40af_0'
+  container SALMON_CONTAINER
   label 'cpus_8'
   tag "${id}-${index}"
   publishDir "${params.outdir}"
@@ -89,7 +94,7 @@ process alevin{
 
 //generate permit list from RAD input 
 process generate_permit{
-  container 'quay.io/biocontainers/alevin-fry:0.4.1--h7d875b9_0'
+  container ALEVINFRY_CONTAINER
   publishDir "${params.outdir}"
   input:
     path run_dir
@@ -110,7 +115,7 @@ process generate_permit{
 
 // given permit list and barcode mapping, collate RAD file 
 process collate_fry{
-  container 'quay.io/biocontainers/alevin-fry:0.4.1--h7d875b9_0'
+  container ALEVINFRY_CONTAINER
   label 'cpus_8'
   publishDir "${params.outdir}"
   input: 
@@ -128,7 +133,7 @@ process collate_fry{
 
 // then quantify collated RAD file
 process quant_fry{
-  container 'quay.io/biocontainers/alevin-fry:0.4.1--h7d875b9_0'
+  container ALEVINFRY_CONTAINER
   label 'cpus_8'
   publishDir "${params.outdir}"
   input: 

--- a/workflows/alevin-quant/run-alevin.nf
+++ b/workflows/alevin-quant/run-alevin.nf
@@ -25,7 +25,7 @@ params.mito_path = "${params.ref_dir}/${params.annotation_dir}/${params.mitolist
 tech_list = ['10Xv2', '10Xv3', '10Xv3.1'] 
 
 process alevin{
-  container 'quay.io/biocontainers/salmon:1.4.0--hf69c8f4_0'
+  container 'quay.io/biocontainers/salmon:1.5.2--h84f40af_0'
   label 'cpus_8'
   tag "${id}-${index}"
   publishDir "${params.outdir}"


### PR DESCRIPTION
Does what it says on the tin! As of Salmon version 1.5.0, the `--tgMap` option is not needed with `--rad`, so I removed it from the alevin workflow.

These version updates add much more informative output files for all stages of the workflow. Notably, though, the output file from `alevin quant` changes from `meta_info.json` to `quant.json`, which will require changes to scpcaTools (tracked in https://github.com/AlexsLemonade/scpcaTools/issues/24)

Closes #118