### PR TITLE
CITE-seq workflo

### DIFF
--- a/workflows/alevin-quant/run-af-feature.nf
+++ b/workflows/alevin-quant/run-af-feature.nf
@@ -8,9 +8,9 @@ params.run_metafile = 's3://ccdl-scpca-data/sample_info/scpca-library-metadata.t
 params.outdir = "s3://nextflow-ccdl-results/scpca/alevin-fry-features"
 
 // 10X barcode files
-barcodes = ['CITE-seq-10Xv2': '737K-august-2016.txt',
-            'CITE-seq-10Xv3': '3M-february-2018.txt',
-            'CITE-seq-10Xv3.1': '3M-february-2018.txt']
+barcodes = ['CITEseq_10Xv2': '737K-august-2016.txt',
+            'CITEseq_10Xv3': '3M-february-2018.txt',
+            'CITEseq_10Xv3.1': '3M-february-2018.txt']
 // supported single cell technologies
 tech_list = barcodes.keySet()
 
@@ -54,9 +54,9 @@ process alevin_feature{
     // label the run directory by id
     run_dir = "${id}-features"
     // Define umi geometries
-    umi_geoms = ['CITE-seq-10Xv2': '1[17-26]',
-                 'CITE-seq-10Xv3': '1[17-28]',
-                 'CITE-seq-10Xv2': '1[17-28]']
+    umi_geoms = ['CITEseq_10Xv2': '1[17-26]',
+                 'CITEseq_10Xv3': '1[17-28]',
+                 'CITEseq_10Xv3.1': '1[17-28]']
     """
     mkdir -p ${run_dir}
     salmon alevin \
@@ -137,7 +137,6 @@ workflow{
                       )}
     .combine(index_feature.out, by: 0) // combine by the feature_barcode_file
     .map{ it.subList(1, it.size())} // remove the first element
-  
 
   // run Alevin
   alevin_feature(reads_ch)


### PR DESCRIPTION
This PR adds a workflow to perform CITE-seq mapping and quantification with `salmon alevin`/`alevin-fry`. This workflow does not yet combine these data with the scRNAseq results; that will come in a separate PR, likely when incorporating these results into `scpca-nf`. For now, the goal is partly to have a set of output files that we can use to develop the steps required for creating SingleCellExperiment objects with both modalities of data.

This workflow is based largely on the existing `alevin-fry` workflow, but adds some elements and other changes. 

* Indexing is incorporated into this workflow, as the barcode index files may vary by sample. Indexing is very fast for these tiny files, but there are a couple of considerations to make it more efficient: 
  * The workflow first creates a channel that finds all unique feature barcode files from the requested sets, and indexes each only once.
  * The  feature index channel is then joined to the feature reads channel, matched by that index name, this is then sent for mapping.
  * The feature index also contains a dummy transcript 2 gene mapping file, which is needed by `alevin quant`. Since the index directory is small, we just pass along the whole index directory in the mapping output, though we could pass just the file. It should be a pretty easy change.

* I combined all `alevin-fry` steps into a single process. This should reduce some of the copying to and from S3, and should speed the workflow in general. We may well want to incorporate a similar change into RNAseq quantification workflow.

* In preparation for when the CITE-seq and RNA quants are merged, I made this workflow pass both `run_id` and `sample_id` along with the other required inputs and output. I think we will probably want to do something like this for the  `scpca-nf` workflow, so while we don't really use these here, this was a good place for a proof of concept.

I *think* we will be able to just combine RNA and CITE-seq by `sample_id` (using something similar to the `.combine` step here, but I will need to check that this works always. If it is not the case, we may need to add another column to the library info table which indicates which `run_id` contains the corresponding RNA for each CITE-seq or cell hash sample.

