### PR TITLE
Increase standard image disk size

### DIFF
--- a/aws/nextflow-launch-templates.tf
+++ b/aws/nextflow-launch-templates.tf
@@ -6,7 +6,7 @@ resource "aws_launch_template" "nf_lt_standard" {
   block_device_mappings {
     device_name = "/dev/xvda"
     ebs {
-      volume_size = 64
+      volume_size = 128
       encrypted = true
       delete_on_termination = true
     }

--- a/aws/nextflow-launch-templates.tf
+++ b/aws/nextflow-launch-templates.tf
@@ -11,6 +11,7 @@ resource "aws_launch_template" "nf_lt_standard" {
       delete_on_termination = true
     }
   }
+  update_default_version = true
 }
 
 resource "aws_launch_template" "nf_lt_bigdisk" {
@@ -26,4 +27,5 @@ resource "aws_launch_template" "nf_lt_bigdisk" {
       delete_on_termination = true
     }
   }
+  update_default_version = true
 }


### PR DESCRIPTION
I ran out of disk when testing one of the new data sets with a larger library. So I decided to just bump the base disk size. Hopefully 2x is sufficient. 

An alternative strategy is to make more disk sizes, and have initial alevin processing use a larger disk, with later (fry) steps smaller, but this seemed sufficient for now.