### PR TITLE
Add scpcaTools to scpca-r image

### DIFF
--- a/images/scpca-r/Dockerfile
+++ b/images/scpca-r/Dockerfile
@@ -34,6 +34,7 @@ RUN Rscript -e "install.packages(c( \
 RUN Rscript -e "BiocManager::install(c( \
     'AnnotationHub', \
     'Biostrings', \
+    'bluster', \
     'BSgenome', \
     'DropletUtils', \
     'eisaR', \
@@ -44,6 +45,10 @@ RUN Rscript -e "BiocManager::install(c( \
     'scater', \
     'tximport'), \
     update = FALSE)"
+
+##########################
+# Install scpcaTools package
+RUN Rscript -e "remotes::install_github('AlexsLemonade/scpcaTools')"
 
 # set final workdir for commands
 WORKDIR /home/rstudio

--- a/images/scpca-r/Dockerfile
+++ b/images/scpca-r/Dockerfile
@@ -41,8 +41,11 @@ RUN Rscript -e "BiocManager::install(c( \
     'ensembldb', \
     'fishpond', \
     'GenomicFeatures', \
+    'LoomExperiment', \
     'scran', \
     'scater', \
+    'SingleCellExperiment', \
+    'SummarizedExperiment', \
     'tximport'), \
     update = FALSE)"
 


### PR DESCRIPTION
Closes #113

This modifies the docker image to include the latest version of the `scpcaTools` package (as of whenever the image are built, so this is not currently versioned).

I also added a couple other packages that might be useful; some are added just to be explicit.

I debated tying `scpcaTools` to a specific commit, but that seemed like overkill, at least for now. If we get to the point where we are tagging releases, it might be worth adding that to the `install_github` call, but that seems like a future issue.