### PR TITLE
Modify cellranger workflow to allow for 5' samples

### DIFF
--- a/workflows/cellranger-quant/run-cellranger.nf
+++ b/workflows/cellranger-quant/run-cellranger.nf
@@ -13,7 +13,7 @@ params.run_ids = "SCPCR000001,SCPCR000002"
 params.outdir = 's3://nextflow-ccdl-results/scpca/cellranger-quant'
 
 // technology options
-tech_list = ["10Xv2", "10Xv3", "10Xv3.1"]
+tech_list = ["10Xv2", "10Xv3", "10Xv3.1", "10Xv2_5prime"]
 
 // build full paths
 params.index_path = "${params.ref_dir}/${params.index_dir}/${params.index_name}"


### PR DESCRIPTION
In order to run the 5' samples through Cell Ranger, I had to add in 5' to the list of acceptable technologies. Pretty straight forward as I added it to the `tech_list` and then was able to run Cell ranger with 5' libraries successfully. 