### PR TITLE
Add 5' support for alevin-fry workflow

### DIFF
--- a/workflows/alevin-quant/run-alevin-fry.nf
+++ b/workflows/alevin-quant/run-alevin-fry.nf
@@ -81,7 +81,7 @@ process alevin{
     """
     mkdir -p ${run_dir}
     salmon alevin \
-      -l ${tech == '10Xv2_5prime' ? 'lISF' : 'lISR'} \
+      -l ${tech == '10Xv2_5prime' ? 'ISF' : 'ISR'} \
       ${tech_flag[tech]} \
       -1 ${read1} \
       -2 ${read2} \

--- a/workflows/alevin-quant/run-alevin-fry.nf
+++ b/workflows/alevin-quant/run-alevin-fry.nf
@@ -34,7 +34,8 @@ t2g_map = ['cdna': 'Homo_sapiens.GRCh38.103.spliced.tx2gene.tsv',
 // 10X barcode files
 barcodes = ['10Xv2': '737K-august-2016.txt',
             '10Xv3': '3M-february-2018.txt',
-            '10Xv3.1': '3M-february-2018.txt']
+            '10Xv3.1': '3M-february-2018.txt',
+            '10Xv2_5prime': '737K-august-2016.txt']
 
 // supported single cell technologies
 tech_list = barcodes.keySet()
@@ -72,14 +73,15 @@ process alevin{
     // choose flag by technology
     tech_flag = ['10Xv2': '--chromium',
                  '10Xv3': '--chromiumV3',
-                 '10Xv3.1': '--chromiumV3']
+                 '10Xv3.1': '--chromiumV3',
+                 '10Xv2_5prime': '--chromium']
     // run alevin like normal with the --rad flag 
     // creates output directory with RAD file needed for alevin-fry
     // uses sketch mode if --sketch was included at invocation
     """
     mkdir -p ${run_dir}
     salmon alevin \
-      -l ISR \
+      -l ${tech == '10Xv2_5prime' ? 'lISF' : 'lISR'} \
       ${tech_flag[tech]} \
       -1 ${read1} \
       -2 ${read2} \


### PR DESCRIPTION
Closes #79. This PR adds in the ability to run 5' libraries using the alevin-fry workflow in this repo that we have been using for testing and benchmarking. I chose to keep things fairly simple here and added `10Xv2_5prime` to the `barcodes` and subsequently the `tech_list` to allow any sample with that technology to be run. 

According to https://github.com/COMBINE-lab/salmon/issues/439#issuecomment-547208043, we can modify Alevin-fry to work with 5' libraries by changing the  library type from `-lISR` to `-lISF`. To do this, I added in a ternary operator that will change the library type only when the 5' libraries are being used. I thought this would be the most straight forward way to do this for testing here, but I'm open to other suggestions on a better way to incorporate this change. 