### PR TITLE
add orientation switch to af permit list step

### DIFF
--- a/workflows/alevin-quant/run-alevin-fry.nf
+++ b/workflows/alevin-quant/run-alevin-fry.nf
@@ -63,7 +63,7 @@ process alevin{
     tuple val(id), val(tech), path(read1), path(read2)
     path index
   output:
-    path run_dir
+    tuple val(id), val(tech), path(run_dir) 
   script:
     // label the run directory by id, index, and mapping mode
     run_dir = "${id}-${index}-${params.sketch ? 'sketch' : 'salign'}-${params.resolution}"
@@ -81,7 +81,7 @@ process alevin{
     """
     mkdir -p ${run_dir}
     salmon alevin \
-      -l ${tech == '10Xv2_5prime' ? 'ISF' : 'ISR'} \
+      -l ISR \
       ${tech_flag[tech]} \
       -1 ${read1} \
       -2 ${read2} \
@@ -99,7 +99,7 @@ process generate_permit{
   container ALEVINFRY_CONTAINER
   publishDir "${params.outdir}"
   input:
-    path run_dir
+    tuple val(id), val(tech), path(run_dir)
     path barcode_file
   output:
     path run_dir
@@ -109,7 +109,7 @@ process generate_permit{
     """
     alevin-fry generate-permit-list \
       -i ${run_dir} \
-      --expected-ori fw \
+      --expected-ori ${tech == '10Xv2_5prime' ? 'rc' : 'fw'}  \
       -o ${run_dir} \
       ${filter_map[params.filter]}
     """


### PR DESCRIPTION
After helpful comments from @rob-p, I realized that we didn't do our orientation flip for 5' data in the correct place! 
https://github.com/AlexsLemonade/alsf-scpca/pull/137#issuecomment-920553327

This PR should fix that (or at least allow testing properly). I went with leaving the library orientation flag alone in the initial step, as that apparently should not matter, but we have to pass the tech along at least one more step, so I modified some inputs and outputs (in the scpca-nf workflow, this is already done).

For now, I went with the `rc` option for the 5' data, but we might still consider `both` as we do seem to have at a pretty significant number of forward reads from the previous analysis!

I should say that this change has not been directly tested as of filing this PR; I wanted to get the suggested changes posted before I will have a chance to do any testing. @ally-hawkins, if you have time to work on testing, that would be great!