### PR TITLE
Add star indexing workflow

### DIFF
--- a/workflows/genetic-demux/index-star.nf
+++ b/workflows/genetic-demux/index-star.nf
@@ -12,7 +12,8 @@ STARCONTAINER = 'quay.io/biocontainers/star:2.7.9a--h9ee0642_0'
 process index_star{
   container STARCONTAINER
   publishDir "${params.ref_dir}/star_index", mode: 'copy'
-  label 'cpus_8'
+  memory "64.GB"
+  cpus "8"
   input:
     path ref_fasta
     path ref_gtf
@@ -32,7 +33,7 @@ process index_star{
       --genomeFastaFiles ${params.assembly}.fa \
       --sjdbGTFfile ${params.assembly}.gtf \
       --sjdbOverhang 100 \
-      --limitGenomeGenerateRAM 26000000000
+      --limitGenomeGenerateRAM 64000000000
     
     # clean up
     rm ${params.assembly}.fa

--- a/workflows/genetic-demux/index-star.nf
+++ b/workflows/genetic-demux/index-star.nf
@@ -20,7 +20,7 @@ process index_star{
   output:
     path output_dir
   script:
-    output_dir = "${params.assembly}"
+    output_dir = "${params.assembly}.star_idx"
     """
     mkdir ${output_dir}
 

--- a/workflows/genetic-demux/index-star.nf
+++ b/workflows/genetic-demux/index-star.nf
@@ -1,0 +1,46 @@
+#!/usr/bin/env nextflow
+nextflow.enable.dsl=2
+
+// parameters
+params.assembly  = 'Homo_sapiens.GRCh38.104'
+params.ref_dir   = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104'
+params.ref_fasta = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz'
+params.ref_gtf   = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.gtf.gz'
+
+STARCONTAINER = 'quay.io/biocontainers/star:2.7.9a--h9ee0642_0'
+
+process index_star{
+  container STARCONTAINER
+  publishDir "${params.ref_dir}/star_index", mode: 'copy'
+  label 'cpus_8'
+  input:
+    path ref_fasta
+    path ref_gtf
+  output:
+    path output_dir
+  script:
+    output_dir = "${params.assembly}"
+    """
+    mkdir ${output_dir}
+
+    # star needs uncompressed fasta & gtf
+    gunzip -c ${ref_fasta} > ${params.assembly}.fa
+    gunzip -c ${ref_gtf} > ${params.assembly}.gtf
+    STAR --runMode genomeGenerate \
+      --runThreadN ${task.cpus} \
+      --genomeDir ${output_dir} \
+      --genomeFastaFiles ${params.assembly}.fa \
+      --sjdbGTFfile ${params.assembly}.gtf \
+      --sjdbOverhang 100 \
+      --limitGenomeGenerateRAM 26000000000
+    
+    # clean up
+    rm ${params.assembly}.fa
+    rm ${params.assembly}.gtf
+    """
+}
+
+workflow{
+  // index with star
+  index_star(params.ref_fasta, params.ref_gtf)
+}


### PR DESCRIPTION
As part of the genetic demulitplexing https://github.com/AlexsLemonade/alsf-scpca/issues/127, we need a STAR genome index. We will use this for bulk mapping to find SNPs.

This PR adds a workflow to create that index, putting the result with the other indices we have created at: s3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/star_index/

Currently the index is based on the full gtf file; it might be a bit smaller if we reduced it to the gtf file that only includes the genes in the transcriptome gtf; I may test this.

Otherwise, this should be a pretty simple workflow. My only annoyance is that the input files had to be decompressed on disk :-(. 

The other question was the naming of the index output directory. I named it just with the Assembly, but I could add some suffix, like `.star_idx` if that seemed like something worth doing.