### PR TITLE
Add bulk mapping with star

### DIFF
--- a/workflows/genetic-demux/map-bulk-star.nf
+++ b/workflows/genetic-demux/map-bulk-star.nf
@@ -74,7 +74,6 @@ workflow{
     // only bulk samples
     .filter{it.technology in bulk_techs} 
     // use only the rows in the run_id list (run, library, or sample can match)
-    // or run by project or submitter if the project parameter is set
     .filter{run_all 
              || (it.run_id in run_ids) 
             }

--- a/workflows/genetic-demux/map-bulk-star.nf
+++ b/workflows/genetic-demux/map-bulk-star.nf
@@ -69,9 +69,6 @@ workflow{
       project_id: it.scpca_project_id?: "no_project",
       submitter: it.submitter,
       technology: it.technology,
-      seq_unit: it.seq_unit,
-      feature_barcode_file: it.feature_barcode_file,
-      feature_barcode_geom: it.feature_barcode_geom,
       s3_prefix: it.s3_prefix,
     ]}
     // only bulk samples

--- a/workflows/genetic-demux/map-bulk-star.nf
+++ b/workflows/genetic-demux/map-bulk-star.nf
@@ -25,8 +25,7 @@ process bulkmap_star{
   output:
     tuple val(meta), path(output_bam)
   script:
-    output_dir = "${meta.library_id}"
-    output_bam = "${output_dir}/Aligned.sortedByCoord.out.bam"
+    output_bam = "${meta.run_id}.sorted.bam"
     """
     STAR \
       --genomeDir ${star_index} \
@@ -34,14 +33,15 @@ process bulkmap_star{
       --readFilesIn ${read1.join(',')} \
       ${meta.technology == 'paired_end' ? read2.join(',') : ""} \
       --readFilesCommand gunzip -c \
-      --outFileNamePrefix ${output_dir}/ \
-      --outSAMtype BAM SortedByCoordinate 
+      --outSAMtype BAM SortedByCoordinate
+
+    mv Aligned.sortedByCoord.out.bam ${output_bam}
     """
 }
 
 process index_bam{
   container SAMTOOLSCONTAINER
-  publishDir "${params.outdir}"
+  publishDir "${params.outdir}/${meta.library_id}"
   input:
     tuple val(meta), path(bamfile)
   output:

--- a/workflows/genetic-demux/map-bulk-star.nf
+++ b/workflows/genetic-demux/map-bulk-star.nf
@@ -1,0 +1,74 @@
+#!/usr/bin/env nextflow
+nextflow.enable.dsl=2
+
+// parameters
+params.ref  = 'Homo_sapiens.GRCh38.104'
+params.star_index = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/star_index/Homo_sapiens.GRCh38.104.star_idx'
+
+params.run_metafile = 's3://ccdl-scpca-data/sample_info/scpca-library-metadata.tsv'
+params.run_ids = 'SCPCR000166'
+
+params.outdir = 's3://nextflow-ccdl-results/scpca/star-bulk/'
+
+STARCONTAINER = 'quay.io/biocontainers/star:2.7.9a--h9ee0642_0'
+
+process bulkmap_star{
+  container STARCONTAINER
+  memory "32.GB"
+  cpus "8"
+  publishDir "${params.outdir}"
+  input:
+    tuple val(meta), path(read1), path(read2)
+    path star_index
+  output:
+    tuple val(meta), path(output_dir)
+  script:
+    output_dir = "${meta.library_id}"
+    """
+    STAR \
+      --genomeDir ${star_index} \
+      --runThreadN ${task.cpus} \
+      --readFilesIn ${read1.join(',')} \
+      ${meta.technology == 'paired_end' ? read2.join(',') : ""} \
+      --readFilesCommand gunzip -c \
+      --outFileNamePrefix ${output_dir}/ \
+      --outSAMtype BAM SortedByCoordinate 
+    """
+}
+
+workflow{
+  bulk_techs = ['single_end', 'paired_end']
+  run_ids = params.run_ids?.tokenize(',') ?: []
+  run_all = run_ids[0] == "All"
+
+  bulk_ch = Channel.fromPath(params.run_metafile)
+    .splitCsv(header: true, sep: '\t')
+    // convert row data to a metadata map, keeping only columns we will need (& some renaming)
+    // sample_id can have multiple `;`-separated values, change to `_`
+    .map{[
+      run_id: it.scpca_run_id,
+      library_id: it.scpca_library_id,
+      sample_id: it.scpca_sample_id.replaceAll(";", "_"),
+      project_id: it.scpca_project_id?: "no_project",
+      submitter: it.submitter,
+      technology: it.technology,
+      seq_unit: it.seq_unit,
+      feature_barcode_file: it.feature_barcode_file,
+      feature_barcode_geom: it.feature_barcode_geom,
+      s3_prefix: it.s3_prefix,
+    ]}
+    // only bulk samples
+    .filter{it.technology in bulk_techs} 
+    // use only the rows in the run_id list (run, library, or sample can match)
+    // or run by project or submitter if the project parameter is set
+    .filter{run_all 
+             || (it.run_id in run_ids) 
+            }
+    
+    bulk_reads_ch = bulk_ch
+      .map{meta -> tuple(meta,
+                         file("s3://${meta.s3_prefix}/*_R1_*.fastq.gz"),
+                         file("s3://${meta.s3_prefix}/*_R2_*.fastq.gz"))}
+    
+    bulkmap_star(bulk_reads_ch, params.star_index)
+}


### PR DESCRIPTION
As part of the genetic demulitplexing #127, we need to map bulk RNAseq data that we will use to discover SNPs in individual samples.

This PR adds a workflow to perform such mapping from bulk samples to create a BAM file and index it. Because the STAR image doesn't contain samtools, we have to do this in two steps, which is a bit annoying, but isn't terrible.

I am not saving/passing along the full STAR output folder, only the BAM file. The other files are small, so it would not be a burden to do that. I would probably in that case leave original file output name (fixed by STAR), and modify the samtools index script to take the directory and output it. But this seemed more direct, especially for a proof of concept.