### PR TITLE
Add support for spatial transcriptomics libraries to Alevin-fry and Cell Ranger workflows

### DIFF
--- a/images/cellranger/Dockerfile
+++ b/images/cellranger/Dockerfile
@@ -8,8 +8,13 @@ RUN rpm -i bcl2fastq2.rpm
 
 # Install cellranger
 WORKDIR /opt
-COPY cellranger-6.0.1.tar.gz cellranger-6.0.1.tar.gz
-RUN tar xzf cellranger-6.0.1.tar.gz && rm cellranger-6.0.1.tar.gz
-ENV PATH="/opt/cellranger-6.0.1:${PATH}"
+COPY cellranger-6.1.2.tar.gz cellranger-6.1.2.tar.gz
+RUN tar xzf cellranger-6.1.2.tar.gz && rm cellranger-6.1.2.tar.gz
+ENV PATH="/opt/cellranger-6.1.2:${PATH}"
+
+# Install spaceranger
+COPY spaceranger-1.3.1.tar.gz spaceranger-1.3.1.tar.gz
+RUN tar xzf spaceranger-1.3.1.tar.gz && rm spaceranger-1.3.1.tar.gz
+ENV PATH="/opt/spaceranger-1.3.1:${PATH}"
 
 WORKDIR /home

--- a/images/cellranger/Dockerfile
+++ b/images/cellranger/Dockerfile
@@ -12,9 +12,4 @@ COPY cellranger-6.1.2.tar.gz cellranger-6.1.2.tar.gz
 RUN tar xzf cellranger-6.1.2.tar.gz && rm cellranger-6.1.2.tar.gz
 ENV PATH="/opt/cellranger-6.1.2:${PATH}"
 
-# Install spaceranger
-COPY spaceranger-1.3.1.tar.gz spaceranger-1.3.1.tar.gz
-RUN tar xzf spaceranger-1.3.1.tar.gz && rm spaceranger-1.3.1.tar.gz
-ENV PATH="/opt/spaceranger-1.3.1:${PATH}"
-
 WORKDIR /home

--- a/images/cellranger/README.md
+++ b/images/cellranger/README.md
@@ -4,7 +4,7 @@ This folder contains a Dockerfile for the cellranger analysis.
 ## Building the image
 
 In order to build this image, the cellranger software and bcl2fastq source code components must be downloaded separately to comply with licensing, and should be placed in this folder (`images/cellranger`).
-- The current version of cellranger is `cellranger-6.0.1.tar.gz` and can be downloaded from [10X Genomics Website](https://support.10xgenomics.com/single-cell-gene-expression/software/downloads/6.0) after agreeing to their license terms.
+- The current version of cellranger is `cellranger-6.1.2.tar.gz` and can be downloaded from [10X Genomics Website](https://support.10xgenomics.com/single-cell-gene-expression/software/downloads/6.0) after agreeing to their license terms.
 - The current version of bcl2fastq is 2.20.0 and can be downloaded from [Illumina](https://support.illumina.com/sequencing/sequencing_software/bcl2fastq-conversion-software.html) after logging into an Illumina account.
   - As we are using an Centos image, you will need to download the "Linux rpm" version of the software.
   - Note that the file Illumina provides to download is a `.zip` file that should contain the `bcl2fastq2-v2.20.0.422-Linux-x86_64.rpm` file specified in the `Dockerfile`. 
@@ -12,7 +12,7 @@ In order to build this image, the cellranger software and bcl2fastq source code 
 Following download of cellranger and bcl2fastq, you can build the image running the following command from this `images/cellranger` working directory:
 
 ```
-docker build . -t scpca-cellranger:6.0.1
+docker build . -t scpca-cellranger:6.1.2
 ```
 
 At this point, the image should be ready for use on the local machine.
@@ -43,8 +43,8 @@ If the updated image needs to be pushed to AWS ECR, you can follow the outline s
 The current image was pushed with the following commands.
 
 ```
-docker tag scpca-cellranger:6.0.1 589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:latest
-docker tag scpca-cellranger:6.0.1 589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:6.0.1
-docker push 589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:6.0.1
+docker tag scpca-cellranger:6.1.2 589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:latest
+docker tag scpca-cellranger:6.1.2 589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:6.1.2
+docker push 589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:6.1.2
 docker push 589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:latest
 ```

--- a/images/spaceranger/Dockerfile
+++ b/images/spaceranger/Dockerfile
@@ -1,0 +1,9 @@
+FROM centos:7
+LABEL maintainer="ccdl@alexslemonade.org"
+
+# Install spaceranger
+COPY spaceranger-1.3.1.tar.gz spaceranger-1.3.1.tar.gz
+RUN tar xzf spaceranger-1.3.1.tar.gz && rm spaceranger-1.3.1.tar.gz
+ENV PATH="/opt/spaceranger-1.3.1:${PATH}"
+
+WORKDIR /home

--- a/images/spaceranger/README.md
+++ b/images/spaceranger/README.md
@@ -1,0 +1,47 @@
+This folder contains a Dockerfile for the cellranger analysis.
+
+
+## Building the image
+
+In order to build this image, the spaceranger software source code components must be downloaded separately to comply with licensing, and should be placed in this folder (`images/spaceranger`).
+- The current version of cellranger is `spaceranger-1.3.1.tar.gz` and can be downloaded from [10X Genomics Website](https://support.10xgenomics.com/spatial-gene-expression/software/downloads/latest) after agreeing to their license terms.
+
+Following download of spaceranger, you can build the image running the following command from this `images/spaceranger` working directory:
+
+```
+docker build . -t scpca-spaceranger:1.3.1
+```
+
+At this point, the image should be ready for use on the local machine.
+
+## Using the AWS ECR
+
+To use the AWS ECR docker repository, you will need to login  with:
+```
+aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 589864003899.dkr.ecr.us-east-1.amazonaws.com
+```
+
+Note that for the code above to work, you must have set up `aws` command line tools on your machine, and have run [`aws configure`](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html) to set up your credentials for AWS access.
+This is a private repository; access is only available to Alex's Lemonade (CCDL) users at this time.
+
+### Pulling the current image
+
+To pull the current version of the container (skipping the build steps), you can use the following command (once you are logged in):
+
+```
+docker pull 589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-spaceranger:latest
+```
+
+### Pushing to AWS ECR
+
+If the updated image needs to be pushed to AWS ECR, you can follow the outline steps below (updating version numbers as needed).
+*Do not push an image unless you are sure it is working!*
+
+The current image was pushed with the following commands.
+
+```
+docker tag scpca-spaceranger:1.3.1 589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-spaceranger:latest
+docker tag scpca-spaceranger:1.3.1 589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-spaceranger:1.3.1
+docker push 589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-spaceranger:1.3.1
+docker push 589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-spaceranger:latest
+```

--- a/workflows/alevin-quant/run-alevin-fry.nf
+++ b/workflows/alevin-quant/run-alevin-fry.nf
@@ -36,7 +36,7 @@ barcodes = ['10Xv2': '737K-august-2016.txt',
             '10Xv3': '3M-february-2018.txt',
             '10Xv3.1': '3M-february-2018.txt',
             '10Xv2_5prime': '737K-august-2016.txt',
-            'spatial': '3M-february-2018.txt']
+            'spatial': '']
 
 // supported single cell technologies
 tech_list = barcodes.keySet()

--- a/workflows/alevin-quant/run-alevin-fry.nf
+++ b/workflows/alevin-quant/run-alevin-fry.nf
@@ -35,7 +35,8 @@ t2g_map = ['cdna': 'Homo_sapiens.GRCh38.103.spliced.tx2gene.tsv',
 barcodes = ['10Xv2': '737K-august-2016.txt',
             '10Xv3': '3M-february-2018.txt',
             '10Xv3.1': '3M-february-2018.txt',
-            '10Xv2_5prime': '737K-august-2016.txt']
+            '10Xv2_5prime': '737K-august-2016.txt',
+            'spatial': '3M-february-2018.txt']
 
 // supported single cell technologies
 tech_list = barcodes.keySet()
@@ -74,7 +75,8 @@ process alevin{
     tech_flag = ['10Xv2': '--chromium',
                  '10Xv3': '--chromiumV3',
                  '10Xv3.1': '--chromiumV3',
-                 '10Xv2_5prime': '--chromium']
+                 '10Xv2_5prime': '--chromium',
+                 'spatial': '--chromiumV3']
     // run alevin like normal with the --rad flag 
     // creates output directory with RAD file needed for alevin-fry
     // uses sketch mode if --sketch was included at invocation

--- a/workflows/cellranger-quant/run-cellranger.nf
+++ b/workflows/cellranger-quant/run-cellranger.nf
@@ -40,7 +40,7 @@ process cellranger{
       --sample=${meta.cr_samples} \
       --localcores=${task.cpus} \
       --localmem=${task.memory.toGiga()} \
-      ${meta.include_introns ? '--include-introns' : ''}
+      ${include_introns ? '--include-introns' : ''}
 
     """
 }

--- a/workflows/cellranger-quant/run-cellranger.nf
+++ b/workflows/cellranger-quant/run-cellranger.nf
@@ -31,7 +31,7 @@ process cellranger{
   output:
     path output_id
   script:
-    output_id = "${meta.scpca_library_id}-${index}-${meta.include_introns ? 'pre_mRNA' : 'mRNA'}"
+    output_id = "${meta.scpca_run_id}-${index}-${meta.include_introns ? 'pre_mRNA' : 'mRNA'}"
     """
     cellranger count \
       --id=${output_id} \
@@ -57,7 +57,7 @@ process spaceranger{
   output:
     path output_id
   script:
-    output_id = "${meta.scpca_library_id}-${index}-spatial"
+    output_id = "${meta.scpca_run_id}-${index}-spatial"
     """
     spaceranger count \
       --id=${output_id} \

--- a/workflows/cellranger-quant/run-cellranger.nf
+++ b/workflows/cellranger-quant/run-cellranger.nf
@@ -63,7 +63,7 @@ process spaceranger{
       --id=${output_id} \
       --transcriptome=${index} \
       --fastqs=${fastq_dir} \
-      --sample=${meta.samples} \
+      --sample=${meta.cr_samples} \
       --localcores=${task.cpus} \
       --localmem=${task.memory.toGiga()} \
       --image=${image_file} \

--- a/workflows/cellranger-quant/run-cellranger.nf
+++ b/workflows/cellranger-quant/run-cellranger.nf
@@ -14,7 +14,8 @@ params.outdir = 's3://nextflow-ccdl-results/scpca/cellranger-quant'
 
 // technology options
 cellranger_tech_list = ["10Xv2", "10Xv3", "10Xv3.1", "10Xv2_5prime"]
-all_tech_list = cellranger_tech_list + "spatial"
+spatial_techs = ["spatial", "visium_v1", "visium_v2"]
+all_tech_list = cellranger_tech_list + spatial_techs
 
 // build full paths
 params.index_path = "${params.ref_dir}/${params.index_dir}/${params.index_name}"
@@ -46,7 +47,7 @@ process cellranger{
 }
 
 process spaceranger{
-  container '589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:6.1.2'
+  container '589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-spaceranger:1.3.1'
   publishDir "${params.outdir}", mode: 'copy'
   tag "${meta.scpca_run_id}-${index}-spatial" 
   label 'cpus_8'
@@ -110,7 +111,7 @@ workflow{
                        )}
 
   spaceranger_reads = ch_reads
-    .filter{it.technology == "spatial"}
+    .filter{it.technology in spatial_techs}
     // create tuple of [metadata, fastq dir, and image filename]
     .map{meta -> tuple(meta,
                        file("s3://${meta.s3_prefix}"),


### PR DESCRIPTION
In order to start to address #143, we first needed to be able to process the Spatial libraries. I chose to modify both the alevin-fry and cellranger workflows in this repo to be able to accommodate running the spatial libraries so that next steps would include directly comparing the output from Alevin-fry to using the cell ranger equivalent, space ranger before choosing which workflow we would want to implement in `scpca-nf`. 

There were a few points to consider in doing this: 

- I started by following the [Alevin-fry tutorial on processing spatial data](https://combine-lab.github.io/alevin-fry-tutorials/2021/af-spatial/) and noticed that the actual use of Alevin-fry is no different between a single-cell library or using a spatial library. The main difference is that we actually don't have a barcode file to use during the `generate-permit-list` step for spatial libraries so we are forced to use the `knee-distance` filtering method in Alevin-fry. I even looked at the files that 10X provides when you search the slide serial numbers and the barcodes are not in the file, but only the X,Y coordinates for each spot with an extra code. I feel like there might be some other hidden spot on the 10X website where the barcodes live, but I was unable to find it so for now just tested this with running it using the knee filtering. 

- In order to use `spaceranger` I needed to add it into the docker image. Rather than make a brand new image, I chose to add it into the existing Cell Ranger image. Let me know if this is not the preferred method and I should make a separate image instead. 

- Right now we list all of the files for a sample in the `files` column of `scpca-library-metadata.tsv`, this includes grouping the image file with the fastq files for spatial libraries. I had to add a filtering step within the `getCRSamples` to only grab sample names from the fastq files, otherwise there will be an indexing error since not every file will have `.fastq.gz` appended and the indexing will fail. I also am grabbing the image file by just searching for the `.jpg` extension. An alternative to this would be to create a separate column in the metadata file for the image file from the start and then the filename can be taken from that column explicitly. We will need the image file for other steps downstream in processing with Alevin-fry as well so maybe this is worth doing? 

- While I was working on the cellranger workflow I also chose to modify it to use the same format that we have been using in `scpca-nf` of passing the metadata through the process. 
 