### PR TITLE
Add mpileup workflow

### DIFF
--- a/workflows/genetic-demux/mpileup.nf
+++ b/workflows/genetic-demux/mpileup.nf
@@ -1,0 +1,129 @@
+#!/usr/bin/env nextflow
+nextflow.enable.dsl=2
+
+SAMTOOLSCONTAINER = 'quay.io/biocontainers/samtools:1.14--hb421002_0'
+BCFTOOLSCONTAINER = 'quay.io/biocontainers/bcftools:1.14--h88f3f91_0'
+
+params.run_metafile = 's3://ccdl-scpca-data/sample_info/scpca-library-metadata.tsv'
+params.run_ids = 'SCPCR000533'
+params.outdir = 's3://nextflow-ccdl-results/scpca/demux/mpileup'
+
+params.ref_fasta = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz'
+params.ref_fasta_index = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.fai'
+
+// supported single cell technologies
+single_cell_techs = ['10Xv2', '10Xv3', '10Xv3.1', '10Xv2_5prime']
+
+process mpileup{
+  container BCFTOOLSCONTAINER
+  publishDir "${params.outdir}/${meta.multiplex_library_id}"
+  cpus "2"
+  memory "2.G"
+  input:
+    tuple val(meta), path(bamfiles), path(bamfiles_index)
+    tuple path(reference), path(reference_index)
+  output:
+    tuple val(meta), path(mpileup_file)
+  script:
+    mpileup_file = "${meta.multiplex_library_id}.vcf.gz"
+    """
+    echo "${meta.sample_ids.join('\n')}" > samples.txt
+    bcftools mpileup -Ou \
+      --fasta-ref ${reference} \
+      ${bamfiles} \
+    | bcftools call -Ou --multiallelic-caller --variants-only \
+    | bcftools view -Oz --genotype ^miss \
+    | bcftools reheader -s samples.txt \
+    > ${mpileup_file}
+    """
+}
+
+
+// bulk mapping results as they would come from a channel
+bulk_results = [
+  [ [ // meta 
+      run_id: 'SCPCR000170', 
+      sample_id: 'SCPCS000133', 
+      technology: 'single_end', 
+      seq_unit: 'bulk', 
+      s3_prefix: 'sccdl-scpca-data/runs/SCPCR000170'
+    ],
+    file('s3://nextflow-ccdl-results/scpca/star-bulk/SCPCS000133/SCPCR000170.sorted.bam'),
+    file('s3://nextflow-ccdl-results/scpca/star-bulk/SCPCS000133/SCPCR000170.sorted.bam.bai')
+  ],
+  [ [ 
+      run_id: 'SCPCR000171', 
+      sample_id: 'SCPCS000134', 
+      technology: 'single_end', 
+      seq_unit: 'bulk', 
+      s3_prefix: 'sccdl-scpca-data/runs/SCPCR000171'
+    ],
+    file('s3://nextflow-ccdl-results/scpca/star-bulk/SCPCS000134/SCPCR000171.sorted.bam'),
+    file('s3://nextflow-ccdl-results/scpca/star-bulk/SCPCS000134/SCPCR000171.sorted.bam.bai')
+  ],
+  [ [
+      run_id: 'SCPCR000172', 
+      sample_id: 'SCPCS000135', 
+      technology: 'single_end', 
+      seq_unit: 'bulk', 
+      s3_prefix: 'sccdl-scpca-data/runs/SCPCR000172'
+    ],
+    file('s3://nextflow-ccdl-results/scpca/star-bulk/SCPCS000135/SCPCR000172.sorted.bam'),
+    file('s3://nextflow-ccdl-results/scpca/star-bulk/SCPCS000135/SCPCR000172.sorted.bam.bai')
+  ],
+  [ [
+      run_id: 'SCPCR000173', 
+      sample_id: 'SCPCS000136', 
+      technology: 'single_end', 
+      seq_unit: 'bulk', 
+      s3_prefix: 'sccdl-scpca-data/runs/SCPCR000173'
+    ],
+    file('s3://nextflow-ccdl-results/scpca/star-bulk/SCPCS000136/SCPCR000173.sorted.bam'),
+    file('s3://nextflow-ccdl-results/scpca/star-bulk/SCPCS000136/SCPCR000173.sorted.bam.bai')
+  ]
+]
+
+workflow{
+  run_ids = params.run_ids?.tokenize(',') ?: []
+  run_all = run_ids[0] == "All"
+
+  all_ch = Channel.fromPath(params.run_metafile)
+    .splitCsv(header: true, sep: '\t')
+    .map{[
+      run_id: it.scpca_run_id,
+      library_id: it.scpca_library_id,
+      sample_id: it.scpca_sample_id.replaceAll(";", "_"),
+      project_id: it.scpca_project_id?: "no_project",
+      submitter: it.submitter,
+      technology: it.technology,
+      seq_unit: it.seq_unit,
+      s3_prefix: it.s3_prefix
+    ]}
+    .filter{it.run_id in run_ids}
+
+  // only multiplexed samples as [sample_id, run_id] pairs
+  multiplexed_ch = all_ch.filter{it.technology in single_cell_techs}
+    .filter{it.sample_id.contains("_")} 
+    .map{[tuple(it.sample_id.split("_")), it]} // split out sample ids into a tuple
+    .transpose() // one element per sample (run_ids repeated)
+
+  bulk_ch = Channel.from(bulk_results)
+    // pull sample id out, leave other three fields as is
+    .map{[it[0].sample_id, it[0], it[1], it[2]]}
+  
+  pileup_ch = multiplexed_ch.combine(bulk_ch, by: 0)
+    .groupTuple(by: 1)
+    .map{[
+      [ // create a meta object for each group of files
+        sample_ids: it[0],
+        multiplex_run_id: it[1].run_id,
+        multiplex_library_id: it[1].library_id,
+        bulk_run_ids: it[2].collect{it.run_id},
+        bulk_run_prefixes: it[2].collect{it.s3_prefix}
+      ],
+      it[3], // bamfiles
+      it[4]  // bamfile indexes
+     ]}
+  
+  mpileup(pileup_ch, [params.ref_fasta, params.ref_fasta_index])
+}


### PR DESCRIPTION
~Stacked on #147~

This PR continues to add steps for #127. 

Here I am adding processing a set of bulk samples that have been mapped with STAR to identify variants in a subset of samples. 

There are two major areas of work here:

1. The workflow logic to set up the input data files, identified by the samples that comprise a multiplexed library.
2. The `mpileup` process itself. 

## Workflow logic
For the first part, there is a fair amount of jiggering to get the channels into the correct configuration. For this I use some `map{}` and `transpose()` transformations to pull out various parts and rearrange them. `transpose()` may not be familiar (it was not to me!), but I think of it as a kind of equivalent to `pivot_longer` in the tidyverse, or maybe more `tidyr::separate_rows`: When there is a `tuple` element, it separates that into separate entries in the channel. So I use that to get every sample & mulitplexed library meta object as  pairs for later.
 
Once that is done, I join on the bulk results by `sample_id` with `combine()`. Here I am using some "dummy" data in that it is a channel that comes from data entered in the workflow script, which refers to previous results that I have calculated. In the future, this would be the result of output from `map_bulk_star` workflow, so it should mirror that with `[meta, bamfile, bamindex]` per element of the channel.

After joining, I combine by the multiplex meta objects (which means I get one per run, as they were identical), then restructure again to get an input for the `mpileup` process with a new `meta` object which contains tuples for the `sample_ids`  and other bulk info, but only the single multiplex library id and run ids. I didn't think having all of the metadata from each file was necessary at this point, but I could extend the number of fields we keep. 

I tried to comment this section pretty well, but if there are sections of the logic that are not clear, please let me know.

## mpileup/bcftools parameters

For mpileup, I used what I would consider a pretty standard set of options to get to a compressed vcf file with samples labeled by sample_id (rather than the filenames that would be the default). I used mostly the same procedures as https://github.com/lmweber/snp-dmx-cancer/blob/master/genotype/genotype_bulk_bcftools/genotype_bulk_HGSOC_bcftools.sh but added a step to remove sites with missing genotype calls. My thought here was that if a site is not called in a bulk sample, the chance that it is called in a single cell sample is slim, and the ambiguity of those sites where we don't know at least one sample's genotype will make them less useful for demultiplexing down the line. By some quick tests that I did on a subset of the data, it looked like this could reduced the file size a fair bit. If later testing reveals that we are not getting good demultiplexing calls, I may revisit this decision to see if it makes a difference.

The mpileup process takes about 3-4 hours to run for the whole genome, but it is essentially single-threaded. I use two cpus to give a bit of headroom for the piped steps, and the memory requirements are quite slim. This could potentially be sped up by splitting chromosomes into separate processes, but that would require more complexity. It isn't so slow that it seems unacceptable to me, but that is a potential future improvement.


