### PR TITLE
Fix errors in spaceranger Dockerfile

### DIFF
--- a/images/spaceranger/Dockerfile
+++ b/images/spaceranger/Dockerfile
@@ -2,6 +2,7 @@ FROM centos:7
 LABEL maintainer="ccdl@alexslemonade.org"
 
 # Install spaceranger
+WORKDIR /opt
 COPY spaceranger-1.3.1.tar.gz spaceranger-1.3.1.tar.gz
 RUN tar xzf spaceranger-1.3.1.tar.gz && rm spaceranger-1.3.1.tar.gz
 ENV PATH="/opt/spaceranger-1.3.1:${PATH}"


### PR DESCRIPTION
In testing the Spaceranger workflow that I was adding in `scpca-nf`, I noticed that the docker image that we had for spaceranger was not working properly and did not have Spaceranger properly installed on it. Here, I added one line to go into the correct working directory before copying over spaceranger so that when it gets added to the home path it is done so correctly. I went into the image and ran a test run of spaceranger and everything now works as expected. 