### PR TITLE
Make genetic-demux into a full workflow

### DIFF
--- a/workflows/genetic-demux/cellsnp.nf
+++ b/workflows/genetic-demux/cellsnp.nf
@@ -76,7 +76,8 @@ process cellsnp{
     meta = meta_star
     meta.sample_ids = meta_mpileup.sample_ids
     meta.bulk_run_ids = meta_mpileup.bulk_run_ids
-    barcodes = "${star_quant}/Solo.out/Gene/filtered/barcodes.tsv"
+    quant_dir = ${meta_star.seq_unit} == "nucleus" ? "GeneFull" : "Gene"
+    barcodes = "${star_quant}/Solo.out/${quant_dir}/filtered/barcodes.tsv"
     outdir = "${meta.library_id}_cellSNP"
     """
     cellsnp-lite \

--- a/workflows/genetic-demux/cellsnp.nf
+++ b/workflows/genetic-demux/cellsnp.nf
@@ -6,7 +6,7 @@ CONDACONTAINER = 'continuumio/miniconda3:4.10.3p0'
 
 params.run_metafile = 's3://ccdl-scpca-data/sample_info/scpca-library-metadata.tsv'
 params.run_ids = 'SCPCR000533'
-params.outdir = 's3://nextflow-ccdl-results/scpca/demux/cellsnp'
+params.outdir = 's3://nextflow-ccdl-results/scpca/demux'
 params.barcode_dir = 's3://nextflow-ccdl-data/reference/10X/barcodes'
 
 params.ref_fasta = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz'
@@ -64,7 +64,7 @@ starsolo_quant_results = [
 
 process cellsnp{
   container CELLSNPCONTAINER
-  publishDir "${params.outdir}/${meta.library_id}"
+  publishDir "${params.outdir}/cellsnp/${meta.library_id}"
   label "cpus_8"
   input:
     tuple val(meta_star), path(star_bam), path(star_bai)
@@ -94,7 +94,7 @@ process cellsnp{
 
 process vireo{
   container CONDACONTAINER
-  publishDir "${params.outdir}/${meta.library_id}"
+  publishDir "${params.outdir}/cellsnp/${meta.library_id}"
   label "cpus_8"
   input:
     tuple val(meta), path(cellsnp_dir)

--- a/workflows/genetic-demux/cellsnp.nf
+++ b/workflows/genetic-demux/cellsnp.nf
@@ -60,13 +60,14 @@ workflow cellsnp_vireo {
   main:
     mpileup_ch = mpileup_vcf_ch
       .map{[it[0].multiplex_library_id] + it} // pull out library id for combining
-    star_mpileup_ch = starsolo_bam_ch
-      .combine(starsolo_quant_ch, by: 0) // rejoin starsolo outs by meta object
-      .map{[it[0].library_id] + it} // add library id at start
+    star_mpileup_ch = starsolo_bam_ch.map{[it[0].library_id] + it} // add library id at start
+      .combine(starsolo_quant_ch.map{[it[0].library_id] + it}, by: 0) // join starsolo outs by library_id 
+      .map{[it[0], it[1], it[2], it[3], it[5]]} // remove redundant meta
       .combine(mpileup_ch, by: 0) // join starsolo and mpileup by library id
+      .view()
       .map{it.drop(1)} // drop library id
       //result: [meta, star_bam, star_bai, star_quant, meta_mpileup, vcf_file]
-    
+
     cellsnp(star_mpileup_ch)
     vireo(cellsnp.out)
   emit:

--- a/workflows/genetic-demux/cellsnp.nf
+++ b/workflows/genetic-demux/cellsnp.nf
@@ -15,6 +15,7 @@ process cellsnp{
   container params.CELLSNP_CONTAINER
   publishDir "${params.outdir}/cellsnp/${meta.library_id}"
   label "cpus_8"
+  tag "${meta_star.run_id}"
   input:
     tuple val(meta_star), path(star_bam), path(star_bai), path(star_quant),
           val(meta_mpileup), path(vcf_file)
@@ -43,6 +44,7 @@ process cellsnp{
 process vireo{
   container params.CONDA_CONTAINER
   publishDir "${params.outdir}/cellsnp/${meta.library_id}"
+  tag "${meta.run_id}"
   label "cpus_8"
   input:
     tuple val(meta), path(cellsnp_dir), path(vcf_file)

--- a/workflows/genetic-demux/cellsnp.nf
+++ b/workflows/genetic-demux/cellsnp.nf
@@ -1,16 +1,6 @@
 #!/usr/bin/env nextflow
 nextflow.enable.dsl=2
 
-
-params.run_metafile = 's3://ccdl-scpca-data/sample_info/scpca-library-metadata.tsv'
-params.run_ids = 'SCPCR000533'
-params.outdir = 's3://nextflow-ccdl-results/scpca/demux'
-params.barcode_dir = 's3://nextflow-ccdl-data/reference/10X/barcodes'
-
-params.ref_fasta = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz'
-params.ref_fasta_index = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.fai'
-
-
 process cellsnp{
   container params.CELLSNP_CONTAINER
   publishDir "${params.outdir}/cellsnp/${meta.library_id}"

--- a/workflows/genetic-demux/cellsnp.nf
+++ b/workflows/genetic-demux/cellsnp.nf
@@ -64,12 +64,11 @@ workflow cellsnp_vireo {
       .combine(starsolo_quant_ch.map{[it[0].library_id] + it}, by: 0) // join starsolo outs by library_id 
       .map{[it[0], it[1], it[2], it[3], it[5]]} // remove redundant meta
       .combine(mpileup_ch, by: 0) // join starsolo and mpileup by library id
-      .view()
       .map{it.drop(1)} // drop library id
       //result: [meta, star_bam, star_bai, star_quant, meta_mpileup, vcf_file]
 
-    cellsnp(star_mpileup_ch)
-    vireo(cellsnp.out)
+    cellsnp(star_mpileup_ch) \
+      | vireo
   emit:
     vireo.out
 }

--- a/workflows/genetic-demux/genetic-demux.nf
+++ b/workflows/genetic-demux/genetic-demux.nf
@@ -28,7 +28,7 @@ all_techs = single_cell_techs + bulk_techs
 // include processes
 include { star_bulk } from './map-bulk-star.nf'
 include { star_singlecell } from './map-sc-star.nf'
-include { mpileup } from './mpileup.nf'
+include { pileup_multibulk } from './mpileup.nf'
 include { cellsnp; vireo } from './cellsnp.nf'
 
 workflow{
@@ -71,33 +71,14 @@ workflow{
     .filter{it.sample_id in bulk_samples.getVal()}
   
   // map bulk samples
-  bulk_mapped_ch = star_bulk(bulk_ch)
-    .map{[it[0].sample_id, it[0], it[1], it[2]]} // [sample_id, meta, bam, bai]
+  star_bulk(bulk_ch)
   
-  // combine bulk samples for pileup
-  pileup_ch = multiplex_ch 
-    .map{[it.sample_id.tokenize("_"), it]} // split out sample ids into a tuple
-    .transpose()
-    .combine(bulk_mapped_ch, by: 0) //combine by sample id
-    .groupTuple(by: 1) // group by the multiplex run meta object
-    .map{[
-      [ // create a meta object for each group of files
-        sample_ids: it[0],
-        multiplex_run_id: it[1].run_id,
-        multiplex_library_id: it[1].library_id,
-        bulk_run_ids: it[2].collect{it.run_id},
-        bulk_run_prefixes: it[2].collect{it.s3_prefix}
-      ],
-      it[3], // bamfiles
-      it[4]  // bamfile indexes
-     ]}
-  // pileup bulk samples 
-  mpileup(pileup_ch, [params.ref_fasta, params.ref_fasta_index])
-  
+  // pileup bulk samples by multiplex groups
+  pileup_multibulk(multiplex_ch, star_bulk.out)
 
   // map multiplex
   star_singlecell(multiplex_ch)
   
-  cellsnp(star_singlecell.out.bam, mpileup.out, star_singlecell.out.quant)
-  vireo(cellsnp.out, mpileup.out)
+  cellsnp(star_singlecell.out.bam, pileup_multibulk.out, star_singlecell.out.quant)
+  vireo(cellsnp.out, pileup_multibulk.out)
 }

--- a/workflows/genetic-demux/genetic-demux.nf
+++ b/workflows/genetic-demux/genetic-demux.nf
@@ -1,0 +1,72 @@
+#!/usr/bin/env nextflow
+nextflow.enable.dsl=2
+
+params.run_metafile = 's3://ccdl-scpca-data/sample_info/scpca-library-metadata.tsv'
+params.run_ids = 'SCPCR000533'
+params.outdir = 's3://nextflow-ccdl-results/scpca/demux/cellsnp'
+params.barcode_dir = 's3://nextflow-ccdl-data/reference/10X/barcodes'
+
+params.ref_fasta = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz'
+params.ref_fasta_index = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.fai'
+params.star_index = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/star_index/Homo_sapiens.GRCh38.104.star_idx'
+
+
+// 10X barcode files
+cell_barcodes = [
+  '10Xv2': '737K-august-2016.txt',
+  '10Xv2_5prime': '737K-august-2016.txt',
+  '10Xv3': '3M-february-2018.txt',
+  '10Xv3.1': '3M-february-2018.txt'
+  ]
+
+// supported technologies
+single_cell_techs= cell_barcodes.keySet()
+bulk_techs = ['single_end', 'paired_end']
+all_techs = single_cell_techs + bulk_techs
+
+
+// include processes
+include { bulkmap_star; index_bam } from './map-bulk-star.nf'
+include { starsolo } from './map-sc-star.nf'
+include { mpileup } from './mpileup.nf'
+include { cellsnp; vireo } from './cellsnp.nf'
+
+workflow{
+  run_ids = params.run_ids?.tokenize(',') ?: []
+  run_all = run_ids[0] == "All"
+
+  runs_ch = Channel.fromPath(params.run_metafile)
+    .splitCsv(header: true, sep: '\t')
+    // convert row data to a metadata map, keeping only columns we will need (& some renaming)
+    // sample_id can have multiple `;`-separated values, change to `_`
+    .map{[
+      run_id: it.scpca_run_id,
+      library_id: it.scpca_library_id,
+      sample_id: it.scpca_sample_id.replaceAll(";", "_"),
+      project_id: it.scpca_project_id?: "no_project",
+      submitter: it.submitter,
+      technology: it.technology,
+      seq_unit: it.seq_unit,
+      s3_prefix: it.s3_prefix
+    ]}   
+    // only technologies we know how to process
+    .filter{it.technology in all_techs} 
+
+  multiplex_ch = runs_ch
+    .filter{it.technology in single_cell_techs}
+    .filter{run_all 
+             || (it.run_id in run_ids) 
+             || (it.library_id in run_ids)
+            }
+    .filter{it.sample_id.contains("_")} 
+    .map{[it.sample_id.tokenize("_"), it]} // split out sample ids into a tuple
+    .transpose() // one element per sample (meta objects repeated)
+  
+  bulk_ch = runs_ch
+    .filter {it.technology in bulk_techs}
+    .map{[it.sample_id, it]}
+  
+  multiplex_bulk_ch = multiplex_ch
+    .combine(bulk_ch, by:0)
+    .view()
+}

--- a/workflows/genetic-demux/genetic-demux.nf
+++ b/workflows/genetic-demux/genetic-demux.nf
@@ -3,7 +3,7 @@ nextflow.enable.dsl=2
 
 params.run_metafile = 's3://ccdl-scpca-data/sample_info/scpca-library-metadata.tsv'
 params.run_ids = 'SCPCR000533'
-params.outdir = 's3://nextflow-ccdl-results/scpca/demux/cellsnp'
+params.outdir = 's3://nextflow-ccdl-results/scpca/demux/'
 params.barcode_dir = 's3://nextflow-ccdl-data/reference/10X/barcodes'
 
 params.ref_fasta = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz'

--- a/workflows/genetic-demux/genetic-demux.nf
+++ b/workflows/genetic-demux/genetic-demux.nf
@@ -34,7 +34,7 @@ all_techs = single_cell_techs + bulk_techs
 
 // include processes
 include { star_bulk } from './map-bulk-star.nf'
-include { starsolo_sc } from './map-sc-star.nf'
+include { starsolo_sc } from './map-sc-star.nf' addParams(cell_barcodes: cell_barcodes)
 include { pileup_multibulk } from './mpileup.nf'
 include { cellsnp_vireo } from './cellsnp.nf'
 

--- a/workflows/genetic-demux/map-bulk-star.nf
+++ b/workflows/genetic-demux/map-bulk-star.nf
@@ -3,6 +3,7 @@ nextflow.enable.dsl=2
 
 process bulkmap_star{
   container params.STAR_CONTAINER
+  tag "${meta.run_id}"
   memory "32.GB"
   cpus "8"
   input:
@@ -28,6 +29,7 @@ process bulkmap_star{
 process index_bam{
   container params.SAMTOOLS_CONTAINER
   publishDir "${params.outdir}/star-bulk/${meta.sample_id}"
+  tag "${meta.run_id}"
   input:
     tuple val(meta), path(bamfile)
   output:

--- a/workflows/genetic-demux/map-bulk-star.nf
+++ b/workflows/genetic-demux/map-bulk-star.nf
@@ -86,3 +86,21 @@ workflow{
     bulkmap_star(bulk_reads_ch, params.star_index) \
       | index_bam
 }
+
+workflow star_bulk{
+  take: bulk_channel 
+  // a channel with a map of metadata for each rna library to process
+    
+  main: 
+    // create tuple of (metadata map, [Read 1 files], [Read 2 files])
+    bulk_reads_ch = bulk_channel
+        .map{meta -> tuple(meta,
+                            file("s3://${meta.s3_prefix}/*_R1_*.fastq.gz"),
+                            file("s3://${meta.s3_prefix}/*_R2_*.fastq.gz"))}
+    // map and index
+    bulkmap_star(bulk_reads_ch, params.star_index) \
+    | index_bam
+  
+  emit: 
+    index_bam.out
+}

--- a/workflows/genetic-demux/map-bulk-star.nf
+++ b/workflows/genetic-demux/map-bulk-star.nf
@@ -1,22 +1,8 @@
 #!/usr/bin/env nextflow
 nextflow.enable.dsl=2
 
-STARCONTAINER = 'quay.io/biocontainers/star:2.7.9a--h9ee0642_0'
-SAMTOOLSCONTAINER = 'quay.io/biocontainers/samtools:1.14--hb421002_0'
-
-// parameters
-params.ref  = 'Homo_sapiens.GRCh38.104'
-params.star_index = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/star_index/Homo_sapiens.GRCh38.104.star_idx'
-
-params.run_metafile = 's3://ccdl-scpca-data/sample_info/scpca-library-metadata.tsv'
-params.run_ids = 'SCPCR000170,SCPCR000171,SCPCR000172,SCPCR000173'
-
-params.outdir = 's3://nextflow-ccdl-results/scpca/demux/'
-
-
-
 process bulkmap_star{
-  container STARCONTAINER
+  container params.STAR_CONTAINER
   memory "32.GB"
   cpus "8"
   input:
@@ -40,7 +26,7 @@ process bulkmap_star{
 }
 
 process index_bam{
-  container SAMTOOLSCONTAINER
+  container params.SAMTOOLS_CONTAINER
   publishDir "${params.outdir}/star-bulk/${meta.sample_id}"
   input:
     tuple val(meta), path(bamfile)
@@ -53,43 +39,9 @@ process index_bam{
     """
 }
 
-workflow{
-  bulk_techs = ['single_end', 'paired_end']
-  run_ids = params.run_ids?.tokenize(',') ?: []
-  run_all = run_ids[0] == "All"
-
-  bulk_ch = Channel.fromPath(params.run_metafile)
-    .splitCsv(header: true, sep: '\t')
-    // convert row data to a metadata map, keeping only columns we will need (& some renaming)
-    // sample_id can have multiple `;`-separated values, change to `_`
-    .map{[
-      run_id: it.scpca_run_id,
-      library_id: it.scpca_library_id,
-      sample_id: it.scpca_sample_id.replaceAll(";", "_"),
-      project_id: it.scpca_project_id?: "no_project",
-      submitter: it.submitter,
-      technology: it.technology,
-      s3_prefix: it.s3_prefix,
-    ]}
-    // only bulk samples
-    .filter{it.technology in bulk_techs} 
-    // use only the rows in the run_id list (run, library, or sample can match)
-    .filter{run_all 
-             || (it.run_id in run_ids) 
-            }
-    
-    bulk_reads_ch = bulk_ch
-      .map{meta -> tuple(meta,
-                         file("s3://${meta.s3_prefix}/*_R1_*.fastq.gz"),
-                         file("s3://${meta.s3_prefix}/*_R2_*.fastq.gz"))}
-    
-    bulkmap_star(bulk_reads_ch, params.star_index) \
-      | index_bam
-}
-
 workflow star_bulk{
-  take: bulk_channel 
-  // a channel with a map of metadata for each rna library to process
+  take: 
+    bulk_channel // a channel with a map of metadata for each rna library to process
     
   main: 
     // create tuple of (metadata map, [Read 1 files], [Read 2 files])

--- a/workflows/genetic-demux/map-bulk-star.nf
+++ b/workflows/genetic-demux/map-bulk-star.nf
@@ -11,7 +11,7 @@ params.star_index = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/
 params.run_metafile = 's3://ccdl-scpca-data/sample_info/scpca-library-metadata.tsv'
 params.run_ids = 'SCPCR000170,SCPCR000171,SCPCR000172,SCPCR000173'
 
-params.outdir = 's3://nextflow-ccdl-results/scpca/demux/star-bulk/'
+params.outdir = 's3://nextflow-ccdl-results/scpca/demux/'
 
 
 
@@ -41,7 +41,7 @@ process bulkmap_star{
 
 process index_bam{
   container SAMTOOLSCONTAINER
-  publishDir "${params.outdir}/${meta.sample_id}"
+  publishDir "${params.outdir}/star-bulk/${meta.sample_id}"
   input:
     tuple val(meta), path(bamfile)
   output:

--- a/workflows/genetic-demux/map-sc-star.nf
+++ b/workflows/genetic-demux/map-sc-star.nf
@@ -41,8 +41,10 @@ process starsolo{
                  '10Xv2_5prime': '',
                  '10Xv3': '--soloUMIlen 12',
                  '10Xv3.1': '--soloUMIlen 12']
+    features_flag = ${meta.seq_unit} == "nucleus" ? "--soloFeatures Gene GeneFull" : "--soloFeatures Gene"
     output_dir = "${meta.run_id}_star"
     output_bam = "${meta.run_id}.sorted.bam"
+    
     """
     mkdir -p ${output_dir}/Solo.out/Gene/raw
     STAR \
@@ -53,6 +55,7 @@ process starsolo{
       --readFilesCommand gunzip -c \
       --soloCBwhitelist ${barcode_file} \
       ${tech_flag[meta.technology]} \
+      ${features_flag} \
       --soloCellFilter EmptyDrops_CR \
       --outSAMtype BAM SortedByCoordinate \
       --outSAMattributes NH HI nM AS CR UR CB UB CY UY GX GN \

--- a/workflows/genetic-demux/map-sc-star.nf
+++ b/workflows/genetic-demux/map-sc-star.nf
@@ -14,6 +14,7 @@ single_cell_techs = cell_barcodes.keySet()
 process starsolo{
   container params.STAR_CONTAINER
   publishDir "${params.outdir}/starsolo/${meta.library_id}"
+  tag "${meta.run_id}"
   label 'bigdisk'
   memory "32.GB"
   cpus "8"
@@ -59,6 +60,7 @@ process starsolo{
 process index_bam{
   container params.SAMTOOLS_CONTAINER
   publishDir "${params.outdir}/starsolo/${meta.library_id}"
+  tag "${meta.run_id}"
   input:
     tuple val(meta), path(bamfile)
   output:

--- a/workflows/genetic-demux/map-sc-star.nf
+++ b/workflows/genetic-demux/map-sc-star.nf
@@ -12,7 +12,7 @@ params.barcode_dir = 's3://nextflow-ccdl-data/reference/10X/barcodes'
 params.run_metafile = 's3://ccdl-scpca-data/sample_info/scpca-library-metadata.tsv'
 params.run_ids = 'SCPCR000533'
 
-params.outdir = 's3://nextflow-ccdl-results/scpca/demux/starsolo/'
+params.outdir = 's3://nextflow-ccdl-results/scpca/demux'
 
 // 10X barcode files
 cell_barcodes = ['10Xv2': '737K-august-2016.txt',
@@ -25,7 +25,7 @@ single_cell_techs = cell_barcodes.keySet()
 
 process starsolo{
   container STARCONTAINER
-  publishDir "${params.outdir}/${meta.library_id}"
+  publishDir "${params.outdir}/starsolo/${meta.library_id}"
   label 'bigdisk'
   memory "32.GB"
   cpus "8"
@@ -59,6 +59,7 @@ process starsolo{
       --soloCellFilter EmptyDrops_CR \
       --outSAMtype BAM SortedByCoordinate \
       --outSAMattributes NH HI nM AS CR UR CB UB CY UY GX GN \
+      --outBAMsortingThreadN 2 \
       --limitBAMsortRAM 20000000000 \
       --runDirPerm All_RWX \
       --outFileNamePrefix ${output_dir}/
@@ -69,7 +70,7 @@ process starsolo{
 
 process index_bam{
   container SAMTOOLSCONTAINER
-  publishDir "${params.outdir}/${meta.library_id}"
+  publishDir "${params.outdir}/starsolo/${meta.library_id}"
   input:
     tuple val(meta), path(bamfile)
   output:

--- a/workflows/genetic-demux/map-sc-star.nf
+++ b/workflows/genetic-demux/map-sc-star.nf
@@ -2,15 +2,6 @@
 nextflow.enable.dsl=2
 
 
-// 10X barcode files
-cell_barcodes = ['10Xv2': '737K-august-2016.txt',
-                 '10Xv3': '3M-february-2018.txt',
-                 '10Xv3.1': '3M-february-2018.txt',
-                 '10Xv2_5prime': '737K-august-2016.txt']
-
-// supported single cell technologies
-single_cell_techs = cell_barcodes.keySet()
-
 process starsolo{
   container params.STAR_CONTAINER
   publishDir "${params.outdir}/starsolo/${meta.library_id}"
@@ -83,7 +74,7 @@ workflow starsolo_sc{
                          file("s3://${meta.s3_prefix}/*_R2_*.fastq.gz"))}
 
     cellbarcodes_ch = singlecell_ch
-      .map{file("${params.barcode_dir}/${cell_barcodes[it.technology]}")}
+      .map{file("${params.barcode_dir}/${params.cell_barcodes[it.technology]}")}
 
     starsolo(sc_reads_ch, params.star_index, cellbarcodes_ch)
     index_bam(starsolo.out.star_bam)

--- a/workflows/genetic-demux/map-sc-star.nf
+++ b/workflows/genetic-demux/map-sc-star.nf
@@ -1,18 +1,6 @@
 #!/usr/bin/env nextflow
 nextflow.enable.dsl=2
 
-STARCONTAINER = 'quay.io/biocontainers/star:2.7.9a--h9ee0642_0'
-SAMTOOLSCONTAINER = 'quay.io/biocontainers/samtools:1.14--hb421002_0'
-
-// parameters
-params.ref  = 'Homo_sapiens.GRCh38.104'
-params.star_index = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/star_index/Homo_sapiens.GRCh38.104.star_idx'
-params.barcode_dir = 's3://nextflow-ccdl-data/reference/10X/barcodes'
-
-params.run_metafile = 's3://ccdl-scpca-data/sample_info/scpca-library-metadata.tsv'
-params.run_ids = 'SCPCR000533'
-
-params.outdir = 's3://nextflow-ccdl-results/scpca/demux'
 
 // 10X barcode files
 cell_barcodes = ['10Xv2': '737K-august-2016.txt',
@@ -24,7 +12,7 @@ cell_barcodes = ['10Xv2': '737K-august-2016.txt',
 single_cell_techs = cell_barcodes.keySet()
 
 process starsolo{
-  container STARCONTAINER
+  container params.STAR_CONTAINER
   publishDir "${params.outdir}/starsolo/${meta.library_id}"
   label 'bigdisk'
   memory "32.GB"
@@ -69,7 +57,7 @@ process starsolo{
 }
 
 process index_bam{
-  container SAMTOOLSCONTAINER
+  container params.SAMTOOLS_CONTAINER
   publishDir "${params.outdir}/starsolo/${meta.library_id}"
   input:
     tuple val(meta), path(bamfile)
@@ -82,47 +70,9 @@ process index_bam{
     """
 }
 
-workflow{
-  run_ids = params.run_ids?.tokenize(',') ?: []
-  run_all = run_ids[0] == "All"
-
-  singlecell_ch = Channel.fromPath(params.run_metafile)
-    .splitCsv(header: true, sep: '\t')
-    // convert row data to a metadata map, keeping only columns we will need (& some renaming)
-    // sample_id can have multiple `;`-separated values, change to `_`
-    .map{[
-      run_id: it.scpca_run_id,
-      library_id: it.scpca_library_id,
-      sample_id: it.scpca_sample_id.replaceAll(";", "_"),
-      project_id: it.scpca_project_id?: "no_project",
-      submitter: it.submitter,
-      technology: it.technology,
-      seq_unit: it.seq_unit,
-      s3_prefix: it.s3_prefix,
-    ]}
-    // only single cell samples
-    .filter{it.technology in single_cell_techs}
-    // use only the rows in the run_id list (run, library, or sample can match)
-    // or run by project or submitter if the project parameter is set
-    .filter{run_all
-             || (it.run_id in run_ids)
-            }
-
-    sc_reads_ch = singlecell_ch
-      .map{meta -> tuple(meta,
-                         file("s3://${meta.s3_prefix}/*_R1_*.fastq.gz"),
-                         file("s3://${meta.s3_prefix}/*_R2_*.fastq.gz"))}
-
-    cellbarcodes_ch = singlecell_ch
-      .map{file("${params.barcode_dir}/${cell_barcodes[it.technology]}")}
-
-    starsolo(sc_reads_ch, params.star_index, cellbarcodes_ch)
-    index_bam(starsolo.out.star_bam)
-}
-
-
-workflow star_singlecell{
-  take: singlecell_ch
+workflow starsolo_sc{
+  take:
+    singlecell_ch
 
   main: 
     sc_reads_ch = singlecell_ch

--- a/workflows/genetic-demux/mpileup.nf
+++ b/workflows/genetic-demux/mpileup.nf
@@ -5,8 +5,8 @@ nextflow.enable.dsl=2
 process mpileup{
   container params.BCFTOOLS_CONTAINER
   publishDir "${params.outdir}/mpileup/${meta.multiplex_library_id}"
+  tag "${meta.multiplex_library_id}"
   cpus "2"
-  memory "2.G"
   input:
     tuple val(meta), path(bamfiles), path(bamfiles_index)
     tuple path(ref_fasta), path(ref_index)

--- a/workflows/genetic-demux/mpileup.nf
+++ b/workflows/genetic-demux/mpileup.nf
@@ -131,3 +131,36 @@ workflow{
   
   mpileup(pileup_ch, [params.ref_fasta, params.ref_fasta_index])
 }
+
+workflow pileup_multibulk{
+  take:
+    multiplex_ch // a channel of multiplex meta objects, with sample_ids join by `_` in their ids
+    bulk_mapped_ch // output of bulk mapping: [meta, bamfile, bamfile_index]
+  
+  main:
+    //pull sample to front of bulk_mapped_ch
+    sample_bulk_ch = bulk_mapped_ch
+      .map{[it[0].sample_id, it[0], it[1], it[2]]} 
+
+    pileup_ch = multiplex_ch 
+      .map{[it.sample_id.tokenize("_"), it]} // split out sample ids into a tuple
+      .transpose() // one element per sample (meta objects repeated)
+      .combine(sample_bulk_ch, by: 0) // combine by sample id
+      .groupTuple(by: 1) // group by the multiplex run meta object
+      .map{[
+        [ // create a meta object for each group of files
+          sample_ids: it[0],
+          multiplex_run_id: it[1].run_id,
+          multiplex_library_id: it[1].library_id,
+          bulk_run_ids: it[2].collect{it.run_id},
+          bulk_run_prefixes: it[2].collect{it.s3_prefix}
+        ],
+        it[3], // bamfiles
+        it[4]  // bamfile indexes
+      ]}
+    mpileup(pileup_ch, [params.ref_fasta, params.ref_fasta_index])
+  
+  emit:
+    mpileup.out
+
+}

--- a/workflows/genetic-demux/mpileup.nf
+++ b/workflows/genetic-demux/mpileup.nf
@@ -80,7 +80,7 @@ workflow pileup_multibulk{
   main:
     //pull sample to front of bulk_mapped_ch
     sample_bulk_ch = bulk_mapped_ch
-      .map{[it[0].sample_id, it[0], it[1], it[2]]} 
+      .map{[it[0].sample_id] + it} 
 
     pileup_ch = multiplex_ch 
       .map{[it.sample_id.tokenize("_"), it]} // split out sample ids into a tuple

--- a/workflows/genetic-demux/mpileup.nf
+++ b/workflows/genetic-demux/mpileup.nf
@@ -17,14 +17,11 @@ process mpileup{
     """
     # create sample file to use for header
     echo "${meta.sample_ids.join('\n')}" > samples.txt
-    # decompress reference
-    gunzip -c ${ref_fasta} > reference.fa
-    mv ${ref_index} reference.fa.fai
 
     # call genotypes against reference, filter sites with missing genotypes 
     # & use sample names for header (replacing file names)
     bcftools mpileup -Ou \
-      --fasta-ref reference.fa \
+      --fasta-ref ${ref_fasta} \
       ${bamfiles} \
     | bcftools call -Ou --multiallelic-caller --variants-only \
     | bcftools view -Oz --genotype ^miss \

--- a/workflows/genetic-demux/mpileup.nf
+++ b/workflows/genetic-demux/mpileup.nf
@@ -108,7 +108,7 @@ workflow{
   // only multiplexed samples as [sample_id, run_id] pairs
   multiplexed_ch = all_ch.filter{it.technology in single_cell_techs}
     .filter{it.sample_id.contains("_")} 
-    .map{[tuple(it.sample_id.split("_")), it]} // split out sample ids into a tuple
+    .map{[it.sample_id.tokenize("_"), it]} // split out sample ids into a tuple
     .transpose() // one element per sample (meta objects repeated)
 
   bulk_ch = Channel.from(bulk_results)

--- a/workflows/genetic-demux/mpileup.nf
+++ b/workflows/genetic-demux/mpileup.nf
@@ -1,28 +1,15 @@
 #!/usr/bin/env nextflow
 nextflow.enable.dsl=2
 
-SAMTOOLSCONTAINER = 'quay.io/biocontainers/samtools:1.14--hb421002_0'
-BCFTOOLSCONTAINER = 'quay.io/biocontainers/bcftools:1.14--h88f3f91_0'
-CELLSNPCONTAINER = 'quay.io/biocontainers/cellsnp-lite:1.2.2--h22771d5_0'
-
-params.run_metafile = 's3://ccdl-scpca-data/sample_info/scpca-library-metadata.tsv'
-params.run_ids = 'SCPCR000533'
-params.outdir = 's3://nextflow-ccdl-results/scpca/demux/'
-
-params.ref_fasta = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz'
-params.ref_fasta_index = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.fai'
-
-// supported single cell technologies
-single_cell_techs = ['10Xv2', '10Xv3', '10Xv3.1', '10Xv2_5prime']
 
 process mpileup{
-  container BCFTOOLSCONTAINER
+  container params.BCFTOOLS_CONTAINER
   publishDir "${params.outdir}/mpileup/${meta.multiplex_library_id}"
   cpus "2"
   memory "2.G"
   input:
     tuple val(meta), path(bamfiles), path(bamfiles_index)
-    tuple path(reference), path(reference_index)
+    tuple path(ref_fasta), path(ref_index)
   output:
     tuple val(meta), path(mpileup_file)
   script:
@@ -30,11 +17,14 @@ process mpileup{
     """
     # create sample file to use for header
     echo "${meta.sample_ids.join('\n')}" > samples.txt
-    
+    # decompress reference
+    gunzip -c ${ref_fasta} > reference.fa
+    mv ${ref_index} reference.fa.fai
+
     # call genotypes against reference, filter sites with missing genotypes 
     # & use sample names for header (replacing file names)
     bcftools mpileup -Ou \
-      --fasta-ref ${reference} \
+      --fasta-ref reference.fa \
       ${bamfiles} \
     | bcftools call -Ou --multiallelic-caller --variants-only \
     | bcftools view -Oz --genotype ^miss \
@@ -44,12 +34,12 @@ process mpileup{
 }
 
 process mpileup_cellsnp{
-  container CELLSNPCONTAINER
+  container params.CELLSNP_CONTAINER
   publishDir "${params.outdir}/mpileup_cellsnp/${meta.multiplex_library_id}"
   label "cpus_8"
   input:
     tuple val(meta), path(bamfiles), path(bamfiles_index)
-    tuple path(reference), path(reference_index)
+    tuple path(ref_fasta), path(ref_index)
   output:
     tuple val(meta), path(mpileup_file)
   script:
@@ -59,18 +49,22 @@ process mpileup_cellsnp{
     # create sample and bam file lists
     echo "${meta.sample_ids.join('\n')}" > samples.txt
     echo "${bamfiles.join('\n')}" > bamfiles.txt
+    # decompress reference
+    gunzip -c ${ref_fasta} > reference.fa
+    mv ${ref_index} reference.fa.fai
 
+    # call genotypes against reference with cellsnp
     cellsnp-lite \
       --samFileList bamfiles.txt \
       --sampleList samples.txt \
-      --refseq ${reference} \
+      --refseq reference.fa \
       --UMItag None \
       --cellTAG None \
       --nproc ${task.cpus} \
       --outDir cellsnp \
       --minMAF=0.1 \
       --minCOUNT=20 \
-      --maxDEPTH=1000000 \
+      --maxDEPTH=100000 \
       --genotype \
       --gzip
     
@@ -78,99 +72,9 @@ process mpileup_cellsnp{
     """
 }
 
-
-// bulk mapping results as they would come from a channel
-bulk_results = [
-  [ [ // meta 
-      run_id: 'SCPCR000170', 
-      sample_id: 'SCPCS000133', 
-      technology: 'single_end', 
-      seq_unit: 'bulk', 
-      s3_prefix: 'sccdl-scpca-data/runs/SCPCR000170'
-    ],
-    file('s3://nextflow-ccdl-results/scpca/demux/star-bulk/SCPCS000133/SCPCR000170.sorted.bam'),
-    file('s3://nextflow-ccdl-results/scpca/demux/star-bulk/SCPCS000133/SCPCR000170.sorted.bam.bai')
-  ],
-  [ [ 
-      run_id: 'SCPCR000171', 
-      sample_id: 'SCPCS000134', 
-      technology: 'single_end', 
-      seq_unit: 'bulk', 
-      s3_prefix: 'sccdl-scpca-data/runs/SCPCR000171'
-    ],
-    file('s3://nextflow-ccdl-results/scpca/demux/star-bulk/SCPCS000134/SCPCR000171.sorted.bam'),
-    file('s3://nextflow-ccdl-results/scpca/demux/star-bulk/SCPCS000134/SCPCR000171.sorted.bam.bai')
-  ],
-  [ [
-      run_id: 'SCPCR000172', 
-      sample_id: 'SCPCS000135', 
-      technology: 'single_end', 
-      seq_unit: 'bulk', 
-      s3_prefix: 'sccdl-scpca-data/runs/SCPCR000172'
-    ],
-    file('s3://nextflow-ccdl-results/scpca/demux/star-bulk/SCPCS000135/SCPCR000172.sorted.bam'),
-    file('s3://nextflow-ccdl-results/scpca/demux/star-bulk/SCPCS000135/SCPCR000172.sorted.bam.bai')
-  ],
-  [ [
-      run_id: 'SCPCR000173', 
-      sample_id: 'SCPCS000136', 
-      technology: 'single_end', 
-      seq_unit: 'bulk', 
-      s3_prefix: 'sccdl-scpca-data/runs/SCPCR000173'
-    ],
-    file('s3://nextflow-ccdl-results/scpca/demux/star-bulk/SCPCS000136/SCPCR000173.sorted.bam'),
-    file('s3://nextflow-ccdl-results/scpca/demux/star-bulk/SCPCS000136/SCPCR000173.sorted.bam.bai')
-  ]
-]
-
-workflow{
-  run_ids = params.run_ids?.tokenize(',') ?: []
-  run_all = run_ids[0] == "All"
-
-  all_ch = Channel.fromPath(params.run_metafile)
-    .splitCsv(header: true, sep: '\t')
-    .map{[
-      run_id: it.scpca_run_id,
-      library_id: it.scpca_library_id,
-      sample_id: it.scpca_sample_id.replaceAll(";", "_"),
-      project_id: it.scpca_project_id?: "no_project",
-      submitter: it.submitter,
-      technology: it.technology,
-      seq_unit: it.seq_unit,
-      s3_prefix: it.s3_prefix
-    ]}
-    .filter{it.run_id in run_ids}
-
-  // only multiplexed samples as [sample_id, run_id] pairs
-  multiplexed_ch = all_ch.filter{it.technology in single_cell_techs}
-    .filter{it.sample_id.contains("_")} 
-    .map{[it.sample_id.tokenize("_"), it]} // split out sample ids into a tuple
-    .transpose() // one element per sample (meta objects repeated)
-
-  bulk_ch = Channel.from(bulk_results)
-    // pull sample id out, leave other three fields as is
-    .map{[it[0].sample_id, it[0], it[1], it[2]]}
-  
-  pileup_ch = multiplexed_ch.combine(bulk_ch, by: 0) // combine by sample id
-    .groupTuple(by: 1) // group by the multiplex run meta object
-    .map{[
-      [ // create a meta object for each group of files
-        sample_ids: it[0],
-        multiplex_run_id: it[1].run_id,
-        multiplex_library_id: it[1].library_id,
-        bulk_run_ids: it[2].collect{it.run_id},
-        bulk_run_prefixes: it[2].collect{it.s3_prefix}
-      ],
-      it[3], // bamfiles
-      it[4]  // bamfile indexes
-     ]}
-  
-  mpileup_cellsnp(pileup_ch, [params.ref_fasta, params.ref_fasta_index])
-}
-
 workflow pileup_multibulk{
   take:
-    multiplex_ch // a channel of multiplex meta objects, with sample_ids join by `_` in their ids
+    multiplex_ch // a channel of multiplex meta objects, with sample_ids joined by `_` in their ids
     bulk_mapped_ch // output of bulk mapping: [meta, bamfile, bamfile_index]
   
   main:

--- a/workflows/genetic-demux/mpileup.nf
+++ b/workflows/genetic-demux/mpileup.nf
@@ -30,6 +30,7 @@ process mpileup{
     """
 }
 
+// not currently used: faster than mpileup but may be less accurate
 process mpileup_cellsnp{
   container params.CELLSNP_CONTAINER
   publishDir "${params.outdir}/mpileup_cellsnp/${meta.multiplex_library_id}"

--- a/workflows/genetic-demux/mpileup.nf
+++ b/workflows/genetic-demux/mpileup.nf
@@ -5,7 +5,7 @@ nextflow.enable.dsl=2
 process mpileup{
   container params.BCFTOOLS_CONTAINER
   publishDir "${params.outdir}/mpileup/${meta.multiplex_library_id}"
-  tag "${meta.multiplex_library_id}"
+  tag "${meta.multiplex_run_id}"
   cpus "2"
   input:
     tuple val(meta), path(bamfiles), path(bamfiles_index)

--- a/workflows/nextflow.config
+++ b/workflows/nextflow.config
@@ -14,11 +14,14 @@ profiles{
     process{
       executor = 'awsbatch'
       queue = 'nextflow-batch-default-queue'
+      errorStrategy = { task.attempt < 2 ? 'retry' : 'finish' }
+      maxRetries = 1
+      maxErrors = '-1'
+      memory = { 4.GB * task.attempt}
+      
       withLabel: cpus_8 {
         cpus = 8
         memory = { 28.GB * task.attempt}
-        errorStrategy = { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
-        maxRetries = 1
       }
       withLabel: bigdisk {
         queue = 'nextflow-batch-bigdisk-queue'


### PR DESCRIPTION
This PR creates a `genetic-demux.nf` workflow that combines the earlier individual steps of genetic demultiplexing into a unified workflow that can run from start to finish with only specifying the input run to be processed.

In doing this, I deleted most of the test run setup from earlier workflows, created named workflows for each step with `take` and `emit` statements, and centralized parameters for specifying containers, files, and directories. So while there are a lot of changes, many of them are moving things around a bit and deleting mock data.

The biggest change/additions are:
1. Adding logic to identify and build a channel of the bulk samples that are needed for reference genotyping. 
2. the logic for grouping samples by multiplex library for `mpileup`
3. updating the workflow for cellsnp/vireo, which now includes more logic to pair the vcf files generated by  `mpileup` with the `starsolo` runs. 

I tried to leave comments to explain what is going on in each of those steps, but I might need to add more. nextflow can be a bit obtuse.

When running this, I found that some tweaks to the overall config were needed, so there are a few changes there as well.

Note that there is one process here that is not used: I was doing some testing with calling initial SNPs from the bulk data with cellsnp as well (what they call mode 2b). This is much faster than `mpileup`, but seemed in initial testing to give worse results, I may do a bit more testing with it, so I left the process there, even though no workflow currently uses it. 

