### PR TITLE
Modify alevin-fry to use unfiltered mode with spatial libraries + update default indices 

### DIFF
--- a/workflows/alevin-quant/run-alevin-fry.nf
+++ b/workflows/alevin-quant/run-alevin-fry.nf
@@ -37,7 +37,7 @@ barcodes = ['10Xv2': '737K-august-2016.txt',
             '10Xv3.1': '3M-february-2018.txt',
             '10Xv2_5prime': '737K-august-2016.txt',
             'visium_v1': 'visium-v1.txt',
-            'visium_v2': 'visium-v1.txt',
+            'visium_v2': 'visium-v2.txt',
             'spatial': '']
 
 // supported single cell technologies

--- a/workflows/alevin-quant/run-alevin-fry.nf
+++ b/workflows/alevin-quant/run-alevin-fry.nf
@@ -2,13 +2,13 @@
 nextflow.enable.dsl=2
 
 // run parameters
-params.ref_dir = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-103'
+params.ref_dir = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104'
 params.index_dir = 'salmon_index'
 params.annotation_dir = 'annotation'
 params.index_type = 'cdna' // default index type is cdna, can also use splici
 params.sketch = false // use sketch mode for mapping with flag `--sketch`
 params.resolution = 'full' //default resolution is full, can also use cr-like, cr-like-em, parsimony, and trivial
-params.t2g_3col = 'Homo_sapiens.GRCh38.103.spliced_intron.tx2gene_3col.tsv'
+params.t2g_3col = 'Homo_sapiens.GRCh38.104.spliced_intron.tx2gene_3col.tsv'
 params.barcode_dir = 's3://nextflow-ccdl-data/reference/10X/barcodes' 
 params.filter = 'unfiltered' // default filtering strategy is to use unfiltered, other options include knee (--knee-distance)
 params.run_metafile = 's3://ccdl-scpca-data/sample_info/scpca-library-metadata.tsv'
@@ -24,18 +24,20 @@ ALEVINFRY_CONTAINER = 'quay.io/biocontainers/alevin-fry:0.4.1--h7d875b9_0'
 
 
 // index files 
-index_names_map = ['cdna': 'spliced_txome_k31',
-                   'splici': 'spliced_intron_txome_k31']
+index_names_map = ['cdna': 'Homo_sapiens.GRCh38.104.spliced_cdna.txome',
+                   'splici': 'Homo_sapiens.GRCh38.104.spliced_intron.txome']
 
 // tx2gene 2 column files
-t2g_map = ['cdna': 'Homo_sapiens.GRCh38.103.spliced.tx2gene.tsv',
-           'splici': 'Homo_sapiens.GRCh38.103.spliced_intron.tx2gene.tsv']
+t2g_map = ['cdna': 'Homo_sapiens.GRCh38.104.spliced.tx2gene.tsv',
+           'splici': 'Homo_sapiens.GRCh38.104.spliced_intron.tx2gene.tsv']
 
 // 10X barcode files
 barcodes = ['10Xv2': '737K-august-2016.txt',
             '10Xv3': '3M-february-2018.txt',
             '10Xv3.1': '3M-february-2018.txt',
             '10Xv2_5prime': '737K-august-2016.txt',
+            'visium_v1': 'visium-v1.txt',
+            'visium_v2': 'visium-v1.txt',
             'spatial': '']
 
 // supported single cell technologies
@@ -76,6 +78,8 @@ process alevin{
                  '10Xv3': '--chromiumV3',
                  '10Xv3.1': '--chromiumV3',
                  '10Xv2_5prime': '--chromium',
+                 'visium_v1': '--chromiumV3',
+                 'visium_v2': '--chromiumV3',
                  'spatial': '--chromiumV3']
     // run alevin like normal with the --rad flag 
     // creates output directory with RAD file needed for alevin-fry

--- a/workflows/cellranger-quant/run-cellranger.nf
+++ b/workflows/cellranger-quant/run-cellranger.nf
@@ -24,8 +24,7 @@ process cellranger{
   label 'bigdisk'
   input:
     tuple val(meta), path(fastq_dir), val(include_introns)
-    val index_name
-    path index
+    tuple val(index_name), path(index)
   output:
     path output_id
   script:
@@ -51,8 +50,7 @@ process spaceranger{
   label 'bigdisk'
   input:
     tuple val(meta), path(fastq_dir), file(image_file)
-    val index_name
-    path index
+    tuple val(index_name), path(index)
   output:
     path output_id
   script:
@@ -118,9 +116,9 @@ workflow{
                        )}
 
   // run cellranger
-  cellranger(cellranger_reads, params.index_name, params.index_path)
+  cellranger(cellranger_reads, [params.index_name, params.index_path])
 
   // run spaceranger 
-  spaceranger(spaceranger_reads, params.index_name, params.index_path)
+  spaceranger(spaceranger_reads, [params.index_name, params.index_path])
   
 }

--- a/workflows/cellranger-quant/run-cellranger.nf
+++ b/workflows/cellranger-quant/run-cellranger.nf
@@ -2,9 +2,8 @@
 nextflow.enable.dsl=2
 
 // basic parameters
-params.ref_dir = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-100'
-params.index_dir = 'cellranger_index'
-params.index_name = 'cdna'
+params.index_path = 's3://nextflow-ccdl-data/reference/homo_sapiens/ensembl-104/cellranger_index/Homo_sapiens.GRCh38.104_cellranger_full'
+params.index_name = 'GRCh38_104_cellranger_full'
 
 params.run_metafile = 's3://ccdl-scpca-data/sample_info/scpca-library-metadata.tsv'
 // run_ids are comma separated list to be parsed into a list of run ids,
@@ -17,22 +16,20 @@ cellranger_tech_list = ["10Xv2", "10Xv3", "10Xv3.1", "10Xv2_5prime"]
 spatial_techs = ["spatial", "visium_v1", "visium_v2"]
 all_tech_list = cellranger_tech_list + spatial_techs
 
-// build full paths
-params.index_path = "${params.ref_dir}/${params.index_dir}/${params.index_name}"
-
 process cellranger{
   container '589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:6.1.2'
   publishDir "${params.outdir}", mode: 'copy'
-  tag "${meta.scpca_run_id}-${index}" // add tag for tracking sample names in trace file  
+  tag "${meta.scpca_run_id}-${index_name}" // add tag for tracking sample names in trace file  
   label 'cpus_8'
   label 'bigdisk'
   input:
     tuple val(meta), path(fastq_dir), val(include_introns)
+    val index_name
     path index
   output:
     path output_id
   script:
-    output_id = "${meta.scpca_run_id}-${index}-${meta.include_introns ? 'pre_mRNA' : 'mRNA'}"
+    output_id = "${meta.scpca_run_id}-${index_name}-${meta.include_introns ? 'pre_mRNA' : 'mRNA'}"
     """
     cellranger count \
       --id=${output_id} \
@@ -49,16 +46,17 @@ process cellranger{
 process spaceranger{
   container '589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-spaceranger:1.3.1'
   publishDir "${params.outdir}", mode: 'copy'
-  tag "${meta.scpca_run_id}-${index}-spatial" 
+  tag "${meta.scpca_run_id}-${index_name}-spatial" 
   label 'cpus_8'
   label 'bigdisk'
   input:
     tuple val(meta), path(fastq_dir), file(image_file)
+    val index_name
     path index
   output:
     path output_id
   script:
-    output_id = "${meta.scpca_run_id}-${index}-spatial"
+    output_id = "${meta.scpca_run_id}-${index_name}-spatial"
     """
     spaceranger count \
       --id=${output_id} \
@@ -120,9 +118,9 @@ workflow{
                        )}
 
   // run cellranger
-  cellranger(cellranger_reads, params.index_path)
+  cellranger(cellranger_reads, params.index_name, params.index_path)
 
   // run spaceranger 
-  spaceranger(spaceranger_reads, params.index_path)
+  spaceranger(spaceranger_reads, params.index_name, params.index_path)
   
 }


### PR DESCRIPTION
Closes #158 and also partially addresses #157. 

The first thing that I have done here is modify the alevin-fry workflow to work with spatial libraries with the unfiltered mode in Alevin-fry. To do this I added the barcode lists for visium_v1 and visium_v2 to `s3://nextflow-ccdl-data/reference/10X/barcodes`. I then added the corresponding filenames for the barcode files to the barcodes map and included the `visium_v1` and `visium_v2` options in the technology map. This was all that was needed to allow for unfiltered to work and I tested it with the two benchmarking samples and everything ran smoothly. 

While modifying the alevin-fry workflow, I noticed that it was still using the ensembl version 103. Because as part of #157, we want to make sure we are comparing libraries that have been mapped with indices created from the same ensembl version, I updated both the alevin-fry and cellranger/spaceranger workflows to use the ensembl 104 as the default index (we don't have a cellranger ensembl 103 index). Because the name of the cellranger index includes `.`, it will throw an error in spaceranger since the `--id` option can only include letters, digits, underscores, and dashes. To get around this, I added an `index_name` parameter that is a shortened version of the index directory that can be used to tag the output folder when used during benchmarking. I also combined all of the individual index parameters into one `index_path`.

As a result of this PR we can now include Alevin-fry knee, Alevin-fry unfiltered, and Spaceranger all mapped to the same ensembl version in the ST benchmarking notebook as the next steps. 