### PR TITLE
Update scripts to new metadata format

### DIFF
--- a/workflows/alevin-quant/run-af-feature.nf
+++ b/workflows/alevin-quant/run-af-feature.nf
@@ -128,7 +128,7 @@ workflow{
   //get and map the feature barcode files
   feature_barcodes_ch = feature_runs_ch
     .map{row -> tuple(row.feature_barcode_file,
-                      file("s3://${row.feature_barcode_file}"))}
+                      file("${row.feature_barcode_file}"))}
     .unique()
   index_feature(feature_barcodes_ch)
 
@@ -139,8 +139,8 @@ workflow{
                       row.scpca_run_id,
                       row.scpca_sample_id,
                       row.technology,
-                      file("s3://${row.s3_prefix}/*_R1_*.fastq.gz"),
-                      file("s3://${row.s3_prefix}/*_R2_*.fastq.gz"),
+                      file("${row.files_directory}/*_R1_*.fastq.gz"),
+                      file("${row.files_directory}/*_R2_*.fastq.gz"),
                       row.feature_barcode_geom
                       )}
     .combine(index_feature.out, by: 0) // combine by the feature_barcode_file

--- a/workflows/alevin-quant/run-alevin-fry.nf
+++ b/workflows/alevin-quant/run-alevin-fry.nf
@@ -175,8 +175,8 @@ workflow{
   reads_ch = samples_ch
     .map{row -> tuple(row.scpca_run_id,
                       row.technology,
-                      file("s3://${row.s3_prefix}/*_R1_*.fastq.gz"),
-                      file("s3://${row.s3_prefix}/*_R2_*.fastq.gz"),
+                      file("${row.files_directory}/*_R1_*.fastq.gz"),
+                      file("${row.files_directory}/*_R2_*.fastq.gz"),
                       )}
 
   barcodes_ch = samples_ch

--- a/workflows/alevin-quant/run-alevin.nf
+++ b/workflows/alevin-quant/run-alevin.nf
@@ -66,8 +66,8 @@ workflow{
   reads_ch = samples_ch
     .map{row -> tuple(row.scpca_run_id,
                       row.technology,
-                      file("s3://${row.s3_prefix}/*_R1_*.fastq.gz"),
-                      file("s3://${row.s3_prefix}/*_R2_*.fastq.gz"),
+                      file("${row.files_directory}/*_R1_*.fastq.gz"),
+                      file("${row.files_directory}/*_R2_*.fastq.gz"),
                       )}
   // run Alevin
   alevin(reads_ch, params.index_path, params.t2g_path)

--- a/workflows/benchmarks/alevin-benchmark-indexes.nf
+++ b/workflows/benchmarks/alevin-benchmark-indexes.nf
@@ -41,8 +41,8 @@ workflow{
     .filter{it.scpca_run_id in run_ids} // use only the rows in the sample list
     // create tuple of [sample_id, [Read1 files], [Read2 files]]
     .map{row -> tuple(row.scpca_run_id,
-                      file("s3://${row.s3_prefix}/*_R1_*.fastq.gz"),
-                      file("s3://${row.s3_prefix}/*_R2_*.fastq.gz"),
+                      file("${row.files_directory}/*_R1_*.fastq.gz"),
+                      file("${row.files_directory}/*_R2_*.fastq.gz"),
                       )}
   ch_indexes = Channel.fromList([
     ['cdna_k31_no_sa',

--- a/workflows/cellranger-quant/run-cellranger.nf
+++ b/workflows/cellranger-quant/run-cellranger.nf
@@ -102,7 +102,7 @@ workflow{
     // create tuple of [metadata, fastq dir]
     //.map{it.cr_samples =  getCRsamples(it.files); it}
     .map{meta -> tuple(meta,
-                       file("s3://${meta.s3_prefix}"),
+                       file("${meta.files_directory}"),
                        meta.seq_unit == 'nucleus'
                        )}
 
@@ -110,9 +110,9 @@ workflow{
     .filter{it.technology in spatial_techs}
     // create tuple of [metadata, fastq dir, and image filename]
     .map{meta -> tuple(meta,
-                       file("s3://${meta.s3_prefix}"),
+                       file("${meta.files_directory}"),
                        //getCRsamples(${meta.files}.findAll{it.contains '.fastq.gz'}),
-                       file("s3://${meta.s3_prefix}/*.jpg")
+                       file("${meta.files_directory}/*.jpg")
                        )}
 
   // run cellranger

--- a/workflows/cellranger-quant/run-cellranger4.nf
+++ b/workflows/cellranger-quant/run-cellranger4.nf
@@ -66,7 +66,7 @@ workflow{
     // create tuple of [sample_id, fastq dir]
     .map{row -> tuple(row.scpca_run_id,
                       getCRsamples(row.files),
-                      file("s3://${row.s3_prefix}")
+                      file("${row.files_directory}")
                       )}
   // run cellranger
   cellranger(ch_reads, params.index_path)

--- a/workflows/checks/bin/check_md5_s3.py
+++ b/workflows/checks/bin/check_md5_s3.py
@@ -26,6 +26,8 @@ def main():
     
     # set up s3
     s3 = boto3.client('s3')
+    if args.prefix.startswith('s3://'):
+        args.prefix = args.prefix[5:]
     bucket, prefix = args.prefix.split('/', 1)
 
     for md5, filename in md5_pairs:

--- a/workflows/checks/check-md5.nf
+++ b/workflows/checks/check-md5.nf
@@ -13,6 +13,7 @@ params.run_ids = "SCPCR000001,SCPCR000002"
 process check_md5{
   container 'ghcr.io/alexslemonade/scpca-aws'
   publishDir "${params.outdir}"
+  tag "$id"
   input:
     tuple val(id), val(prefix), path(md5_file) 
   output:

--- a/workflows/checks/check-md5.nf
+++ b/workflows/checks/check-md5.nf
@@ -46,8 +46,8 @@ workflow{
     .splitCsv(header: true, sep: '\t')
     .filter{run_all || (it.scpca_run_id in run_ids)}
     .map{row -> tuple(row.scpca_run_id,
-                      row.s3_prefix,
-                      file("s3://${row.s3_prefix}/${row.md5_file}")
+                      row.files_directory,
+                      file("${row.files_directory}/${row.md5_file}")
                       )}
   check_md5(ch_runs)
   cat_md5(check_md5.out.collect())

--- a/workflows/genetic-demux/genetic-demux.nf
+++ b/workflows/genetic-demux/genetic-demux.nf
@@ -54,7 +54,7 @@ workflow{
       submitter: it.submitter,
       technology: it.technology,
       seq_unit: it.seq_unit,
-      s3_prefix: it.s3_prefix
+      files_directory: it.files_directory
     ]}   
     // only technologies we know how to process
     .filter{it.technology in all_techs} 

--- a/workflows/genetic-demux/map-bulk-star.nf
+++ b/workflows/genetic-demux/map-bulk-star.nf
@@ -49,8 +49,8 @@ workflow star_bulk{
     // create tuple of (metadata map, [Read 1 files], [Read 2 files])
     bulk_reads_ch = bulk_channel
         .map{meta -> tuple(meta,
-                            file("s3://${meta.s3_prefix}/*_R1_*.fastq.gz"),
-                            file("s3://${meta.s3_prefix}/*_R2_*.fastq.gz"))}
+                            file("${meta.files_directory}/*_R1_*.fastq.gz"),
+                            file("${meta.files_directory}/*_R2_*.fastq.gz"))}
     // map and index
     bulkmap_star(bulk_reads_ch, params.star_index) \
     | index_bam

--- a/workflows/genetic-demux/map-sc-star.nf
+++ b/workflows/genetic-demux/map-sc-star.nf
@@ -70,8 +70,8 @@ workflow starsolo_sc{
   main: 
     sc_reads_ch = singlecell_ch
       .map{meta -> tuple(meta,
-                         file("s3://${meta.s3_prefix}/*_R1_*.fastq.gz"),
-                         file("s3://${meta.s3_prefix}/*_R2_*.fastq.gz"))}
+                         file("${meta.files_directory}/*_R1_*.fastq.gz"),
+                         file("${meta.files_directory}/*_R2_*.fastq.gz"))}
 
     cellbarcodes_ch = singlecell_ch
       .map{file("${params.barcode_dir}/${params.cell_barcodes[it.technology]}")}

--- a/workflows/genetic-demux/mpileup.nf
+++ b/workflows/genetic-demux/mpileup.nf
@@ -91,7 +91,7 @@ workflow pileup_multibulk{
           multiplex_run_id: it[1].run_id,
           multiplex_library_id: it[1].library_id,
           bulk_run_ids: it[2].collect{it.run_id},
-          bulk_run_prefixes: it[2].collect{it.s3_prefix}
+          bulk_run_prefixes: it[2].collect{it.files_directory}
         ],
         it[3], // bamfiles
         it[4]  // bamfile indexes

--- a/workflows/kallisto-quant/run-kallisto.nf
+++ b/workflows/kallisto-quant/run-kallisto.nf
@@ -133,8 +133,8 @@ workflow{
   reads_ch = samples_ch
     .map{row -> tuple(row.scpca_run_id,
                       row.technology,
-                      file("s3://${row.s3_prefix}/*_R1_*.fastq.gz"),
-                      file("s3://${row.s3_prefix}/*_R2_*.fastq.gz"),
+                      file("${row.files_directory}/*_R1_*.fastq.gz"),
+                      file("${row.files_directory}/*_R2_*.fastq.gz"),
                       row.seq_unit
                       )}
   barcodes_ch = samples_ch


### PR DESCRIPTION
We changed the format of the metadata file to use the more generic `files`directory` instead of `s3_prefix`, so I am here updating the workflows to handle that change. 

This also required a change to the check_md5_s3.py script, which is included here as well!