### PR TITLE
Print out sample ID with comma in scpca-meta.json

### DIFF
--- a/scripts/update_scpca_checkpoints.py
+++ b/scripts/update_scpca_checkpoints.py
@@ -69,7 +69,7 @@ def process_scrna(run, consts, overwrite):
     metadata = {
         "run_id": run.scpca_run_id,
         "library_id": run.scpca_library_id,
-        "sample_id": run.scpca_sample_id,
+        "sample_id": run.scpca_sample_id.replace(";", ","),
         "project_id": run.scpca_project_id,
         "submitter": run.submitter,
         "technology": run.technology,


### PR DESCRIPTION
This is just a small fix to make sure that the `scpca-meta.json` files in the `checkpoints/rad` directory contain a comma separated list for demultiplexed samples rather than a semi colon separated list. 