### PR TITLE
Script to add ref_mito and ref_fasta_index to scpca-meta.json

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,10 @@
+# Scripts for adding and modifying `scpca-meta.json`
+
+The files in this folder were utilized to create or adjust the `scpca-meta.json` file output by running `scpca-nf`. Specifically, these files were used to synchronize changes in `scpca-nf` with the metadata output, which allows for skipping mapping when re-processing projects through `scpca-nf`.
+
+1. `update_scpca_checkpoints.py`: This script was used to generate the original `scpca-meta.json` files for all libraries that had been processed before `scpca-nf v0.4.0`.
+In this script, the old results from mapping are copied over from the `internal` to `checkpoints` directory.
+Additionally, the `scpca-meta.json` file was created and saved to the `checkpoints` directory for each run to track processing information.
+
+2. `add-refs-scpca-meta.py`: This script specifically updates existing `scpca-meta.json` files within the `checkpoints` directory.
+For any libraries processed through `scpca-nf v0.5.1` or earlier, the `scpca-meta.json` file is modified to include two additional files - `ref_mito` and `ref_fasta_index`.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,4 +7,4 @@ In this script, the old results from mapping are copied over from the `internal`
 Additionally, the `scpca-meta.json` file was created and saved to the `checkpoints` directory for each run to track processing information.
 
 2. `add-refs-scpca-meta.py`: This script specifically updates existing `scpca-meta.json` files within the `checkpoints` directory.
-For any libraries processed through `scpca-nf v0.5.1` or earlier, the `scpca-meta.json` file is modified to include two additional files - `ref_mito` and `ref_fasta_index`.
+For any libraries processed through `scpca-nf v0.5.1` or earlier, the `scpca-meta.json` file is modified to include two additional fields - `ref_mito` and `ref_fasta_index`.

--- a/scripts/add-refs-scpca-meta.py
+++ b/scripts/add-refs-scpca-meta.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import boto3
+import pandas
+
+# Parse command line arguments
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    '--library_file',
+    default='s3://ccdl-scpca-data/sample_info/scpca-library-metadata.tsv',
+    help='path or URI to library data file TSV'
+)
+parser.add_argument(
+    '--bucket',
+    default='nextflow-ccdl-results',
+    help='S3 bucket where results files are located'
+)
+parser.add_argument(
+    '--checkpoints_prefix',
+    default='scpca/processed/checkpoints',
+    help='directory containing checkpoint files to modify'
+)
+parser.add_argument(
+        '--overwrite',
+        action="store_true",
+        help="overwrite existing files at destination"
+    )
+args = parser.parse_args()
+
+# Read in library file
+library_df = pandas.read_csv(args.library_file, sep="\t", keep_default_na=False)
+
+# remove any extra / at the end
+bucket = args.bucket.strip('/')
+checkpoints_prefix = args.checkpoints_prefix.strip('/')
+
+# define techs for setting up checkpionts directories for different modalities
+sc_techs = ["10Xv2", "10Xv2_5prime", "10Xv3", "10Xv3.1"]
+bulk_techs = ['single_end', 'paired_end']
+spatial_techs = ['visium']
+demux_techs = ['cellhash_10Xv2', 'cellhash_10Xv3', 'cellhash_10Xv3.1']
+
+# go through every run id and modify scpca-meta.json file if present
+for run in library_df.itertuples():
+
+    print(f"Processing {run.scpca_run_id}")
+
+    # depending on the technology for that run, define the directory where scpca-meta.json is located
+    if run.technology in sc_techs:
+        checkpoint_folder = f"{checkpoints_prefix}/rad/{run.scpca_library_id}/{run.scpca_run_id}-rna"
+    elif run.technology in bulk_techs:
+        checkpoint_folder = f"{checkpoints_prefix}/salmon/{run.scpca_library_id}"
+    elif run.technology in spatial_techs:
+        checkpoint_folder = f"{checkpoints_prefix}/spaceranger/{run.scpca_library_id}/{run.scpca_run_id}-spatial"
+    elif run.technology in demux_techs:
+        checkpoint_folder = f"{checkpoints_prefix}/vireo/{run.scpca_library_id}-vireo"
+    else:
+        continue
+
+    # define key for scpca-meta.json file
+    meta_json_key = f"{checkpoint_folder}/scpca-meta.json"
+
+    # set up S3
+    s3 = boto3.resource('s3')
+    s3_bucket = s3.Bucket(bucket)
+
+    # read scpca-meta.json, if present
+    try:
+        results_obj = s3_bucket.Object(meta_json_key).get()['Body'].read().decode('utf-8')
+        results_meta = json.loads(results_obj)
+    except s3.meta.client.exceptions.NoSuchKey:
+        print(f"No scpca-meta.json file for {run.scpca_run_id}")
+        continue
+
+    # add mito file and ref fasta index if not already present
+    if all(key in results_meta for key in ('mito_file', 'ref_fasta_index')):
+        print(f"All keys are present, no updates to scpca-meta.json for {run.scpca_run_id}")
+    else:
+        results_meta['mito_file'] = "s3://scpca-references/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.mitogenes.txt"
+        results_meta['ref_fasta_index'] = "homo_sapiens/ensembl-104/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.fai"
+
+    # copy updated json file
+    s3_bucket.put_object(
+        Key=meta_json_key,
+        Body=json.dumps(results_meta, indent=2)
+    )

--- a/scripts/add-refs-scpca-meta.py
+++ b/scripts/add-refs-scpca-meta.py
@@ -22,11 +22,6 @@ parser.add_argument(
     default='scpca/processed/checkpoints',
     help='directory containing checkpoint files to modify'
 )
-parser.add_argument(
-        '--overwrite',
-        action="store_true",
-        help="overwrite existing files at destination"
-    )
 args = parser.parse_args()
 
 # Read in library file

--- a/scripts/add-refs-scpca-meta.py
+++ b/scripts/add-refs-scpca-meta.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python3
 
+"""
+
+This script is meant to add the missing `ref_mito` and `ref_fasta_index` to `scpca-meta.json` checkpoint files
+for previously processed libraries through `scpca-nf`.
+For all runs present in the `--library_file`, this script will check for an existing `scpca-meta.json` file in the provided `--checkpoints_prefix` on S3.
+If the file is not there, that run is skipped.
+If the file is there, the json is loaded and `ref_mito` and `ref_fasta_index` are added if missing.
+
+To run this script for modifying the `scpca-meta.json` files from runs that have already been processed for production do:
+
+python add-refs-scpca-meta.py --checkpoints_prefix "scpca_prod/checkpoints"
+
+"""
+
 import argparse
 import json
 import boto3

--- a/scripts/add-refs-scpca-meta.py
+++ b/scripts/add-refs-scpca-meta.py
@@ -2,12 +2,10 @@
 
 """
 
-This script is meant to add the missing `ref_mito` and `ref_fasta_index` to `scpca-meta.json` checkpoint files
-for previously processed libraries through `scpca-nf`.
+The purpose of this script is to include the 'ref_mito' and 'ref_fasta_index' fields that are missing in the 'scpca-meta.json' checkpoint files of libraries that have been processed through 'scpca-nf' before.
 For all runs present in the `--library_file`, this script will check for an existing `scpca-meta.json` file in the provided `--checkpoints_prefix` on S3.
-If the file is not there, that run is skipped.
-If the file is there, the json is loaded and `ref_mito` and `ref_fasta_index` are added if missing.
-
+If the file is unavailable, the run will be skipped.
+If the file exists, the JSON is loaded, and `ref_mito` and `ref_fasta_index` are added if they are not already present.
 To run this script for modifying the `scpca-meta.json` files from runs that have already been processed for production do:
 
 python add-refs-scpca-meta.py --checkpoints_prefix "scpca_prod/checkpoints"


### PR DESCRIPTION
Closes #173 

Before reprocessing any projects, we need to make sure the `scpca-meta.json` files from previous versions of `scpca-nf` match the `scpca-meta.json` file needed for the latest version (v0.5.2). The difference between these two versions is the addition of `ref_mito` and `ref_fasta_index` to the json files. 

This script runs through all of the libraries in the existing metadata file and does the following:
- Grabs the corresponding `scpca-meta.json` file, using the technology for that run ID to define the path to where the `scpca-meta.json` file should exist. If the file does not exist (as in that sample hasn't been processed), then that sample is skipped. 
- If `ref_mito` and/or `ref_fasta_index` do not exist in the metadata file, those are added to the dictionary holding the json contents. 
- The updated json is uploaded to the same location on S3, overwriting the original file. 

I used the arguments found in `update_scpca_checkpoints.py` for inspiration. Because of that, I have an argument for the `checkpoints_prefix`, which is where the files live that should be modified. I have been testing using `scpca/processed/checkpoints`, but when we run this for real, we will want to use `scpca_prod/checkpoints`. 