### PR TITLE
Update script for adding new fields to `scpca-meta.json` to include assay ontology and submitter cell types

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,5 +6,6 @@ The files in this folder were utilized to create or adjust the `scpca-meta.json`
 In this script, the old results from mapping are copied over from the `internal` to `checkpoints` directory.
 Additionally, the `scpca-meta.json` file was created and saved to the `checkpoints` directory for each run to track processing information.
 
-2. `add-refs-scpca-meta.py`: This script specifically updates existing `scpca-meta.json` files within the `checkpoints` directory.
-For any libraries processed through `scpca-nf v0.5.1` or earlier, the `scpca-meta.json` file is modified to include two additional fields - `ref_mito` and `ref_fasta_index`.
+2. `add-fields-scpca-meta.py`: This script specifically updates existing `scpca-meta.json` files within the `checkpoints` directory.
+For any libraries processed through `scpca-nf v0.5.1` or earlier, the `scpca-meta.json` file is modified to include additional fields that have been added in new release of `scpca-nf`.
+This includes `ref_mito`, `ref_fasta_index`, `assay_ontology_term_id`, and `submitter_cell_types_file`.

--- a/scripts/add-fields-scpca-meta.py
+++ b/scripts/add-fields-scpca-meta.py
@@ -43,7 +43,7 @@ parser.add_argument(
 args = parser.parse_args()
 
 # Read in library file
-library_df = pandas.read_csv(args.library_file, sep="\t", keep_default_na=False).iloc[49:50,]
+library_df = pandas.read_csv(args.library_file, sep="\t", keep_default_na=False)
 
 # remove any extra / at the end
 bucket = args.bucket.strip('/')
@@ -88,7 +88,12 @@ for run in library_df.itertuples():
         continue
 
     # create a list of new fields to check for
-    new_fields = ['mito_file', 'ref_fasta_index', 'assay_ontology_term_id', 'submitter_cell_types_file']
+    new_fields = {
+        'mito_file': "s3://scpca-references/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.mitogenes.txt",
+        'ref_fasta_index': "homo_sapiens/ensembl-104/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.fai",
+        'assay_ontology_term_id', run.assay_ontology_term_id,
+        'submitter_cell_types_file', run.submitter_cell_types_file
+    }
 
     # check if any of the new fields are already present
     # if they are all present, make sure that submitter_cell_types_file is up to date

--- a/scripts/add-fields-scpca-meta.py
+++ b/scripts/add-fields-scpca-meta.py
@@ -43,7 +43,7 @@ parser.add_argument(
 args = parser.parse_args()
 
 # Read in library file
-library_df = pandas.read_csv(args.library_file, sep="\t", keep_default_na=False)
+library_df = pandas.read_csv(args.library_file, sep="\t", keep_default_na=False).iloc[49:50,]
 
 # remove any extra / at the end
 bucket = args.bucket.strip('/')
@@ -90,8 +90,9 @@ for run in library_df.itertuples():
     # create a list of new fields to check for
     new_fields = ['mito_file', 'ref_fasta_index', 'assay_ontology_term_id', 'submitter_cell_types_file']
 
-    # check if any of the new fields are already present, if not add them
-    if all(key in results_meta for key in new_fields):
+    # check if any of the new fields are already present
+    # if they are all present, make sure that submitter_cell_types_file is up to date
+    if all(key in results_meta for key in new_fields) and results_meta['submitter_cell_types_file'] == run.submitter_cell_types_file:
         print(f"All fields are present, no updates to scpca-meta.json for {run.scpca_run_id}")
     else:
         # add any missing fields
@@ -101,7 +102,8 @@ for run in library_df.itertuples():
             results_meta['ref_fasta_index'] = "homo_sapiens/ensembl-104/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.fai"
         if 'assay_ontology_term_id' not in results_meta.keys():
             results_meta['assay_ontology_term_id'] = run.assay_ontology_term_id
-        if 'submitter_cell_types_file' not in results_meta.keys():
+        # update submitter cell types file if it's missing or if the value doesn't match the metadata file
+        if 'submitter_cell_types_file' not in results_meta.keys() or results_meta['submitter_cell_types_file'] != run.submitter_cell_types_file:
             results_meta['submitter_cell_types_file'] = run.submitter_cell_types_file
 
     # copy updated json file

--- a/scripts/add-fields-scpca-meta.py
+++ b/scripts/add-fields-scpca-meta.py
@@ -87,9 +87,10 @@ for run in library_df.itertuples():
         print(f"No scpca-meta.json file for {run.scpca_run_id}")
         continue
 
+    # create a list of new fields to check for
     new_fields = ['mito_file', 'ref_fasta_index', 'assay_ontology_term_id', 'submitter_cell_types_file']
 
-    # add mito file and ref fasta index if not already present
+    # check if any of the new fields are already present, if not add them
     if all(key in results_meta for key in new_fields):
         print(f"All fields are present, no updates to scpca-meta.json for {run.scpca_run_id}")
     else:

--- a/scripts/add-fields-scpca-meta.py
+++ b/scripts/add-fields-scpca-meta.py
@@ -14,7 +14,7 @@ If the file is unavailable, the run will be skipped.
 If the file exists, the JSON is loaded, and the missing fields are added if they are not already present.
 To run this script for modifying the `scpca-meta.json` files from runs that have already been processed for production do:
 
-python add-refs-scpca-meta.py --checkpoints_prefix "scpca_prod/checkpoints"
+python add-fields-scpca-meta.py --checkpoints_prefix "scpca-prod/checkpoints"
 
 """
 

--- a/scripts/add-fields-scpca-meta.py
+++ b/scripts/add-fields-scpca-meta.py
@@ -104,11 +104,11 @@ for run in library_df.itertuples():
             results_meta.setdefault(key, default)
 
         # update submitter cell types file if it's missing or if the value doesn't match the metadata file
-        if 'submitter_cell_types_file' not in results_meta.keys() or results_meta['submitter_cell_types_file'] != run.submitter_cell_types_file:
+        if results_meta.get('submitter_cell_types_file') != run.submitter_cell_types_file:
             results_meta['submitter_cell_types_file'] = run.submitter_cell_types_file
 
 
-        # copy updated json file
+    # copy updated json file
     s3_bucket.put_object(
         Key=meta_json_key,
         Body=json.dumps(results_meta, indent=2)


### PR DESCRIPTION
Closes #175 

Since we have now added two new terms to the initial `scpca-meta.json` in `scpca-nf`, we need to update the existing checkpoints files to include those additions before we re-process for AnnData or cell type additions. 

- I updated the existing `add-refs-scpca-meta.py` to be named `add-fields-scpca-meta.py`. This script can now be used to add any new fields we may need to as we continue development of `scpca-nf`. The readme and documentation for the script usage has now been updated to reflect that. 
- I added a list of new fields that are being added. If all of them are present then no modifications are performed. Otherwise there is a check for each of the new fields individually. Then for each missing one it is added into the meta before exporting. 
- I also am checking to make sure that the submitter cell types file is up to date. I'm envisioning us populating that column as we receive new submissions. Then before we process we should be able to just run this script to update that field to match what we have in the metadata file rather than having to re-map.

I tested this with a library in `scpca/processed` and things worked as expected. Once this is approved, I'll run this for the entire `scpca-prod/checkpoints` folder. 