### PR TITLE
Add entries for `ref_assembly` and `star_index` to `scpca-meta.json` files

### DIFF
--- a/scripts/add-fields-scpca-meta.py
+++ b/scripts/add-fields-scpca-meta.py
@@ -8,6 +8,8 @@ This includes addition of the following missing fields:
 - 'ref_fasta_index'
 - 'assay_ontology_term_id'
 - 'submitter_cell_types_file'
+- 'ref_assembly'
+- 'star_index'
 
 For all runs present in the `--library_file`, this script will check for an existing `scpca-meta.json` file in the provided `--checkpoints_prefix` on S3.
 If the file is unavailable, the run will be skipped.
@@ -94,7 +96,9 @@ for run in library_df.itertuples():
     new_fields = {
         "mito_file": "s3://scpca-references/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.mitogenes.txt",
         "ref_fasta_index": "homo_sapiens/ensembl-104/fasta/Homo_sapiens.GRCh38.dna.primary_assembly.fa.fai",
+        "star_index": "s3://scpca-references/homo_sapiens/ensembl-104/star_index/Homo_sapiens.GRCh38.104.star_idx",
         "assay_ontology_term_id": run.assay_ontology_term_id,
+        "ref_assembly": run.sample_reference
     }
 
     # check if any of the new fields are already present


### PR DESCRIPTION
In working on processing projects through `scpca-nf`, I noticed that the libraries with multiplexing were not skipping genetic demuxing, even though the results files already exist and they should be skipped. When I went to look at why, it was because the `scpca-meta.json` for multiplexed samples did not contain a `ref_assembly` version. That's what we use to check to ensure we skip demultiplexing. Here, I'm updating the script we use to add in fields to the `scpca-meta.json` files to include the `ref_assembly` field. 

When I was poking around, I also noticed that we don't store the `star_index` in `scpca-meta.json` for the multiplexed libraries, but we do for all other libraries. I am also adding that as a field to include in the json files here. 

Note that I updated one of the json files and then re-ran the workflow and things were now skipping genetic demultiplexing as they should be.  