### PR TITLE
Update cell type checkpoints to include the updated reference file names

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,6 +6,10 @@ The files in this folder were utilized to create or adjust the `scpca-meta.json`
 In this script, the old results from mapping are copied over from the `internal` to `checkpoints` directory.
 Additionally, the `scpca-meta.json` file was created and saved to the `checkpoints` directory for each run to track processing information.
 
-2. `add-fields-scpca-meta.py`: This script specifically updates existing `scpca-meta.json` files within the `checkpoints` directory.
+2. `add-fields-scpca-meta.py`: This script specifically updates existing `scpca-meta.json` files within the `checkpoints` directory for mapping steps.
 For any libraries processed through `scpca-nf v0.5.1` or earlier, the `scpca-meta.json` file is modified to include additional fields that have been added in new release of `scpca-nf`.
 This includes `ref_mito`, `ref_fasta_index`, `assay_ontology_term_id`, and `submitter_cell_types_file`.
+
+3. `add-celltype-fields-scpca-meta.py`: This script specifically updates existing `scpca-meta.json` files in the `checkpoints/celltype` directory.
+For any libraries that have been processed through `scpca-nf v0.6.2` or earlier, the `scpca-meta.json` files created for cell type annotation are modified to include the most up-to-date reference file names.
+This includes ensuring that the entries for `singler_model_file` and `cellassign_reference_file` reflect the file names stored in the ScPCA project cell type metadata.

--- a/scripts/add-celltype-fields-scpca-meta.py
+++ b/scripts/add-celltype-fields-scpca-meta.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+
+"""
+
+The purpose of this script is to update the the 'scpca-meta.json' checkpoint files for cell typing of already processed libraries to be up to date with changes in `scpca-nf`.
+This includes addition of the following missing fields in the celltype checkpoints:
+- `singler_ref_version`
+- `cellassign_ref_version`
+
+For all runs present in the `--library_file`, this script will check the `celltype` folder for an existing `scpca-meta.json` file in the provided `--checkpoints_prefix` on S3.
+Both the `scpca-meta.json` for SingleR and CellAssign will be updated.
+If the file is unavailable, the run will be skipped.
+If the file exists, the JSON is loaded, and the missing fields are added if they are not already present.
+To run this script for modifying the cell type `scpca-meta.json` files from runs that have already been processed for production do:
+
+python add-celltype-fields-scpca-meta.py --checkpoints_prefix "scpca-prod/checkpoints"
+
+"""
+
+import argparse
+import json
+import boto3
+import pandas
+
+# Parse command line arguments
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "--library_file",
+    default="s3://ccdl-scpca-data/sample_info/scpca-library-metadata.tsv",
+    help="path or URI to library data file TSV",
+)
+parser.add_argument(
+    "--project_celltype_file",
+    default="s3://ccdl-scpca-data/sample_info/scpca-project-celltype-metadata.tsv",
+    help="path to URI to project cell type data file TSV",
+)
+parser.add_argument(
+    "--bucket",
+    default="nextflow-ccdl-results",
+    help="S3 bucket where results files are located",
+)
+parser.add_argument(
+    "--checkpoints_prefix",
+    default="scpca/processed/checkpoints",
+    help="directory containing checkpoint files to modify",
+)
+args = parser.parse_args()
+
+# Read in library file
+library_df = pandas.read_csv(args.library_file, sep="\t", keep_default_na=False)
+
+# Read in project celltype file
+project_df = pandas.read_csv(
+    args.project_celltype_file, sep="\t", keep_default_na=False
+)
+
+# remove any extra / at the end
+bucket = args.bucket.strip("/")
+checkpoints_prefix = args.checkpoints_prefix.strip("/")
+
+# join library and project cell type metadata
+all_metadata_df = library_df.join(
+    project_df.set_index("scpca_project_id"), on="scpca_project_id", how="left"
+)
+# need to filter to only projects that have at least one reference (either SingleR or CellAssign)
+all_metadata_df = all_metadata_df[
+    all_metadata_df[["singler_ref_file", "cellassign_ref_file"]].notnull().all(1)
+]
+
+# remove any extra / at the end
+bucket = args.bucket.strip("/")
+checkpoints_prefix = args.checkpoints_prefix.strip("/")
+
+# set up S3
+s3 = boto3.resource("s3")
+s3_bucket = s3.Bucket(bucket)
+
+# go through every run id and modify scpca-meta.json files if present
+for run in all_metadata_df.itertuples():
+    print(f"Processing {run.scpca_run_id}")
+
+    # build paths to singleR and CellAssign checkpoints
+    celltype_checkpoints = {
+        "singler_checkpoint": f"{checkpoints_prefix}/celltype/{run.scpca_library_id}/{run.scpca_library_id}_singler/scpca-meta.json",
+        "cellassign_checkpoint": f"{checkpoints_prefix}/celltype/{run.scpca_library_id}/{run.scpca_library_id}_cellassign/scpca-meta.json",
+    }
+
+    # cell type fields that need to be updated
+    new_fields = {
+        "singler_model_file": f"s3://scpca-references/celltype/singler_models/{run.singler_ref_file}",
+        "cellassign_reference_file": f"s3://scpca-references/celltype/cellassign_references/{run.cellassign_ref_file}",
+    }
+
+    # for each checkpoint file, add cellassign and singler file path
+    for checkpoint_file in celltype_checkpoints.values():
+        # make sure file exists, otherwise just skip
+        try:
+            checkpoint_obj = (
+                s3_bucket.Object(checkpoint_file).get()["Body"].read().decode("utf-8")
+            )
+            checkpoint_meta = json.loads(checkpoint_obj)
+        except s3.meta.client.exceptions.NoSuchKey:
+            print(f"No cell type scpca-meta.json file for {run.scpca_run_id}")
+            continue
+
+        # only modify if existing fields don't match what's in the project metadata
+        if (
+            checkpoint_meta["singler_model_file"] == new_fields["singler_model_file"]
+            and checkpoint_meta["cellassign_reference_file"]
+            == new_fields["cellassign_reference_file"]
+        ):
+            print(
+                f"All fields are present, no updates for {run.scpca_run_id} to {checkpoint_file}"
+            )
+        else:
+            # before modifying, make sure that the entries in the project metadata isn't NA
+            if run.singler_ref_file != "NA":
+                checkpoint_meta["singler_model_file"] = new_fields["singler_model_file"]
+            if run.cellassign_ref_file != "NA":
+                checkpoint_meta["cellassign_reference_file"] = new_fields[
+                    "cellassign_reference_file"
+                ]
+
+        # copy updated json file
+        s3_bucket.put_object(
+            Key=checkpoint_file, Body=json.dumps(checkpoint_meta, indent=2)
+        )

--- a/scripts/add-fields-scpca-meta.py
+++ b/scripts/add-fields-scpca-meta.py
@@ -3,7 +3,7 @@
 """
 
 The purpose of this script is to update the the 'scpca-meta.json' checkpoint files of already processed libraries to be up to date with changes in `scpca-nf`.
-This includes addition of the following missing fields:
+This includes addition of the following missing fields in the mapping checkpoints:
 - 'ref_mito'
 - 'ref_fasta_index'
 - 'assay_ontology_term_id'
@@ -14,6 +14,9 @@ This includes addition of the following missing fields:
 For all runs present in the `--library_file`, this script will check for an existing `scpca-meta.json` file in the provided `--checkpoints_prefix` on S3.
 If the file is unavailable, the run will be skipped.
 If the file exists, the JSON is loaded, and the missing fields are added if they are not already present.
+NOTE: This script only updates the `scpca-meta.json` files for mapping results.
+For cell type metadata changes, see `add-celltype-fields-scpca-meta.py`.
+
 To run this script for modifying the `scpca-meta.json` files from runs that have already been processed for production do:
 
 python add-fields-scpca-meta.py --checkpoints_prefix "scpca-prod/checkpoints"


### PR DESCRIPTION
Related to https://github.com/AlexsLemonade/ScPCA-admin/issues/691

We recently updated the reference file names for both `SingleR` and `CellAssign`. Before doing this, we had previously run a few samples through both `SingleR` and `CellAssign`. To skip cell typing, we check that the reference file name stored in `library_id_cellassign/scpca-meta.json` and `library_id_singler/scpca-meta.json` match the reference file names that have been passed through the workflow via the project metadata. If we want to run the projects through again and skip running `CellAssign` for samples that already have `CellAssign` results, then these reference files need to be updated in the `scpca-meta.json` files. 

Here I'm adding a script that specifically updates the cell type `scpca-meta.json` files to make sure that the reference file names match what's in `scpca-project-celltype-metadata.tsv`. It's mostly modeled after the script we use for updating the mapping related `scpca-meta.json` files, but here we need to update two checkpoint files per library, one for each method. 

Also we want to account for values that may already be there, but with a different file name. So we directly compare what's in the checkpoint file vs. what's in the metadata file and update accordingly. Additionally, if `NA` is in the project metadata, then we don't set the path and fill with NA. Although this shouldn't really affect any of the files that will get updated here. I removed all old `SingleR` files, so in reality only the `CellAssign` results are getting updated, and they only exist if there was a reference file in the first place. 

I've tested this with runs in `scpca/processed`. Once this gets approved I'll run for `scpca-prod`. 