### PR TITLE
Add back priority queue

### DIFF
--- a/aws/nextflow-batch.tf
+++ b/aws/nextflow-batch.tf
@@ -1,6 +1,5 @@
 # AWS Batch setup
 provider "aws" {
-  profile = "default"
   region  = "us-east-1"
 }
 
@@ -47,11 +46,11 @@ resource "aws_batch_job_queue" "nf_autoscale_queue" {
 }
 
 
-# resource "aws_batch_job_queue" "nf_priority_queue" {
-#   name     = "nextflow-batch-priority-queue"
-#   state    = "ENABLED"
-#   priority = 1
-#   compute_environments = [
-#     aws_batch_compute_environment.nf_ondemand.arn,
-#   ]
-# }
+resource "aws_batch_job_queue" "nf_priority_queue" {
+  name     = "nextflow-batch-priority-queue"
+  state    = "ENABLED"
+  priority = 1
+  compute_environments = [
+    aws_batch_compute_environment.nf_ondemand.arn,
+  ]
+}

--- a/aws/nextflow-compute.tf
+++ b/aws/nextflow-compute.tf
@@ -90,7 +90,7 @@ resource "aws_batch_compute_environment" "nf_spot_bigdisk" {
   depends_on   = [aws_iam_role_policy_attachment.nf_batch_role]
 }
 
-# Create a spot instance environment with up to 128 vcpus and auto-scaled EBS.
+# Create a spot instance environment with up to 256 vcpus and auto-scaled EBS.
 resource "aws_batch_compute_environment" "nf_spot_auto_scaled_ebs" {
   compute_environment_name = "nextflow-spot-compute-auto-scaled-ebs"
   tags = var.default_tags
@@ -102,7 +102,7 @@ resource "aws_batch_compute_environment" "nf_spot_auto_scaled_ebs" {
     allocation_strategy = "SPOT_CAPACITY_OPTIMIZED"
     spot_iam_fleet_role = aws_iam_role.nf_spotfleet_role.arn
     bid_percentage = 100
-    max_vcpus = 128
+    max_vcpus = 256
     min_vcpus = 0
 
     launch_template {
@@ -129,42 +129,40 @@ resource "aws_batch_compute_environment" "nf_spot_auto_scaled_ebs" {
   depends_on   = [aws_iam_role_policy_attachment.nf_batch_role]
 }
 
-# # Create an ondemand environment with up to 32 vcpus
-# # the AMI used is described in setup-log.md
-# resource "aws_batch_compute_environment" "nf_ondemand" {
-#   compute_environment_name = "nextflow-ondemand-compute"
-#   tags = var.default_tags
-#   compute_resources {
-#     instance_role = aws_iam_instance_profile.nf_ecs_instance_role.arn
-#     instance_type = [
-#       "optimal",
-#     ]
-#     allocation_strategy = "BEST_FIT"
-#     max_vcpus = 32
-#     min_vcpus = 0
-#     # standard launch template
-#     launch_template {
-#       launch_template_id = aws_launch_template.nf_lt_standard.id
-#     }
-#     # ec2_key_pair = aws_key_pair.nf_keypair.key_name
-#     security_group_ids = [
-#       aws_security_group.nf_security.id,
-#     ]
-#     subnets = [
-#       aws_subnet.nf_subnet.id,
-#     ]
-#     type = "EC2"
-#     tags = merge(
-#       var.default_tags,
-#       {
-#         parent = "nextflow-ondemand-compute"
-#       }
-#     )
-#   }
-
-#   service_role = aws_iam_role.nf_batch_role.arn
-#   type         = "MANAGED"
-#   depends_on   = [aws_iam_role_policy_attachment.nf_batch_role]
-
-# }
-
+# Create an ondemand environment with up to 64 vcpus
+# the AMI used is described in setup-log.md
+resource "aws_batch_compute_environment" "nf_ondemand" {
+  compute_environment_name = "nextflow-ondemand-compute"
+  tags = var.default_tags
+  compute_resources {
+    instance_role = aws_iam_instance_profile.nf_ecs_instance_role.arn
+    instance_type = [
+      "optimal",
+    ]
+    allocation_strategy = "BEST_FIT"
+    max_vcpus = 64
+    min_vcpus = 0
+    # standard launch template
+    launch_template {
+      launch_template_id = aws_launch_template.nf_lt_auto_scaled_ebs.id
+      version = aws_launch_template.nf_lt_auto_scaled_ebs.latest_version
+    }
+    # ec2_key_pair = aws_key_pair.nf_keypair.key_name
+    security_group_ids = [
+      aws_security_group.nf_security.id,
+    ]
+    subnets = [
+      aws_subnet.nf_subnet.id,
+    ]
+    type = "EC2"
+    tags = merge(
+      var.default_tags,
+      {
+        parent = "nextflow-ondemand-compute"
+      }
+    )
+  }
+  service_role = aws_iam_role.nf_batch_role.arn
+  type         = "MANAGED"
+  depends_on   = [aws_iam_role_policy_attachment.nf_batch_role]
+}

--- a/aws/nextflow-compute.tf
+++ b/aws/nextflow-compute.tf
@@ -129,8 +129,7 @@ resource "aws_batch_compute_environment" "nf_spot_auto_scaled_ebs" {
   depends_on   = [aws_iam_role_policy_attachment.nf_batch_role]
 }
 
-# Create an ondemand environment with up to 64 vcpus
-# the AMI used is described in setup-log.md
+# Create an ondemand environment with up to 128 vcpus
 resource "aws_batch_compute_environment" "nf_ondemand" {
   compute_environment_name = "nextflow-ondemand-compute"
   tags = var.default_tags
@@ -140,7 +139,7 @@ resource "aws_batch_compute_environment" "nf_ondemand" {
       "optimal",
     ]
     allocation_strategy = "BEST_FIT"
-    max_vcpus = 64
+    max_vcpus = 128
     min_vcpus = 0
     # standard launch template
     launch_template {


### PR DESCRIPTION
This PR adds a priority queue to our nextflow batch configs. 

Mostly this was uncommenting previous code, but I also changed the ondemand queue to use the auto-scaling ebs volumes that are part of the main queue that we use.

I had to be a bit manual with the `apply`, as I didn't have the current state file, but I put the current state file after applying my changes in S3.

Requesting @davidsmejia for review since @arkid15r is out.

