### PR TITLE
Use named instance types for batch

### DIFF
--- a/aws/nextflow-compute.tf
+++ b/aws/nextflow-compute.tf
@@ -18,7 +18,7 @@ resource "aws_batch_compute_environment" "nf_spot" {
     instance_type = [
       "optimal",
     ]
-    allocation_strategy = "SPOT_CAPACITY_OPTIMIZED"
+    allocation_strategy = "SPOT_PRICE_CAPACITY_OPTIMIZED"
     spot_iam_fleet_role = aws_iam_role.nf_spotfleet_role.arn
     bid_percentage = 100
     max_vcpus = 256
@@ -59,7 +59,7 @@ resource "aws_batch_compute_environment" "nf_spot_bigdisk" {
     instance_type = [
       "optimal",
     ]
-    allocation_strategy = "SPOT_CAPACITY_OPTIMIZED"
+    allocation_strategy = "SPOT_PRICE_CAPACITY_OPTIMIZED"
     spot_iam_fleet_role = aws_iam_role.nf_spotfleet_role.arn
     bid_percentage = 100
     max_vcpus = 128
@@ -97,9 +97,13 @@ resource "aws_batch_compute_environment" "nf_spot_auto_scaled_ebs" {
   compute_resources {
     instance_role = aws_iam_instance_profile.nf_ecs_instance_role.arn
     instance_type = [
-      "optimal",
+      "C4", "M4", "R4",
+      "C5", "M5", "R5",
+      "C5a", "M5a", "R5a",
+      "C6i", "M6i", "R6i",
+      "C6a", "M6a", "R6a",
     ]
-    allocation_strategy = "SPOT_CAPACITY_OPTIMIZED"
+    allocation_strategy = "SPOT_PRICE_CAPACITY_OPTIMIZED"
     spot_iam_fleet_role = aws_iam_role.nf_spotfleet_role.arn
     bid_percentage = 100
     max_vcpus = 2048
@@ -136,7 +140,11 @@ resource "aws_batch_compute_environment" "nf_ondemand" {
   compute_resources {
     instance_role = aws_iam_instance_profile.nf_ecs_instance_role.arn
     instance_type = [
-      "optimal",
+      "C4", "M4", "R4",
+      "C5", "M5", "R5",
+      "C5a", "M5a", "R5a",
+      "C6i", "M6i", "R6i",
+      "C6a", "M6a", "R6a",
     ]
     allocation_strategy = "BEST_FIT"
     max_vcpus = 512

--- a/aws/nextflow-compute.tf
+++ b/aws/nextflow-compute.tf
@@ -97,11 +97,11 @@ resource "aws_batch_compute_environment" "nf_spot_auto_scaled_ebs" {
   compute_resources {
     instance_role = aws_iam_instance_profile.nf_ecs_instance_role.arn
     instance_type = [
-      "C4", "M4", "R4",
-      "C5", "M5", "R5",
-      "C5a", "M5a", "R5a",
-      "C6i", "M6i", "R6i",
-      "C6a", "M6a", "R6a",
+      "c4", "m4", "r4",
+      "c5", "m5", "r5",
+      "c5a", "m5a", "r5a",
+      "c6i", "m6i", "r6i",
+      "c6a", "m6a", "r6a",
     ]
     allocation_strategy = "SPOT_PRICE_CAPACITY_OPTIMIZED"
     spot_iam_fleet_role = aws_iam_role.nf_spotfleet_role.arn
@@ -140,11 +140,11 @@ resource "aws_batch_compute_environment" "nf_ondemand" {
   compute_resources {
     instance_role = aws_iam_instance_profile.nf_ecs_instance_role.arn
     instance_type = [
-      "C4", "M4", "R4",
-      "C5", "M5", "R5",
-      "C5a", "M5a", "R5a",
-      "C6i", "M6i", "R6i",
-      "C6a", "M6a", "R6a",
+      "c4", "m4", "r4",
+      "c5", "m5", "r5",
+      "c5a", "m5a", "r5a",
+      "c6i", "m6i", "r6i",
+      "c6a", "m6a", "r6a",
     ]
     allocation_strategy = "BEST_FIT"
     max_vcpus = 512


### PR DESCRIPTION
Here I am switching from using the "optimal" instances, which are all 4-series, to named instance types for our batch compute environments. This is related to https://github.com/AlexsLemonade/scpca-nf/issues/709 where we may need more memory than available in the R4 instances. 

I also switched to the new `SPOT_PRICE_CAPACITY_OPTIMIZED` allocation strategy where applicable, because that might control costs a bit better, especially given the fact that we are now allowing more expensive instance types.

I wasn't sure whether it was worth including both Intel and AMD instance types, but it doesn't seem like it should hurt?

I have not yet applied this change; I am waiting for review of my choices here.