### PR TITLE
Specify library IDs to use when updating fields in scpca-meta.json

### DIFF
--- a/scripts/add-fields-scpca-meta.py
+++ b/scripts/add-fields-scpca-meta.py
@@ -58,10 +58,10 @@ library_df = pandas.read_csv(args.library_file, sep="\t", keep_default_na=False)
 # otherwise keep the full library df
 if args.library_ids:
     # get a list of library_ids
-    library_ids = args.library_ids.split(",")
+    library_ids = set(args.library_ids.split(","))
 
     # check that library ids are present in library metadata
-    if not all(id in library_df["scpca_library_id"].tolist() for id in library_ids):
+    if not library_ids.issubset(library_df["scpca_library_id"].unique()):
         raise ValueError(f"All {library_ids} not found in {args.library_file}")
 
     # filter library df to only include specified library ids


### PR DESCRIPTION
In processing some of the merged objects, I noticed that the community contributed datasets had out of date `scpca-meta.json` files that were missing the `assay_ontology_term_id` and the `submitter_cell_types_file` field. We already have a script that updates these files to include any new fields we have added later on, but this script currently updates all `scpca-meta.json` files for all libraries in the library metadata. 

In case we need to make other updates to specific libraries in the future, I made this a bit more flexible to update only a specific set of library IDs. A comma-separated list of library IDs can be provided as an optional argument. If they are provided, the library metadata is filtered before going through each library and updating the json files. Otherwise, the whole metadata file is used. 

Note that I ran this script today for the two community-contributed datasets, so they now have complete `scpca-meta.json` files. 