### PR TITLE
Update base image to alma linux for cell ranger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,8 +53,9 @@ workflows/*/data/
 
 # Ignore software downloads
 *.rpm
-images/cellranger/cellranger*.tar.gz
-images/cellranger/bcl2fastq*.tar.gz
+images/cellranger/cellranger-*
+images/cellranger/bcl2fastq*
+images/spaceranger/spaceranger-*
 
 # Ignore nextflow logs
 workflows/nextflow_logs/

--- a/images/cellranger/Dockerfile
+++ b/images/cellranger/Dockerfile
@@ -1,15 +1,13 @@
-FROM centos:7
+FROM almalinux:9
 LABEL maintainer="ccdl@alexslemonade.org"
 
 # Install bcl2fastq
 WORKDIR /tmp
 COPY bcl2fastq2-v2.20.0.422-Linux-x86_64.rpm bcl2fastq2.rpm
-RUN rpm -i bcl2fastq2.rpm 
+RUN rpm -i bcl2fastq2.rpm
 
 # Install cellranger
-WORKDIR /opt
-COPY cellranger-9.0.1.tar.gz cellranger-9.0.1.tar.gz
-RUN tar xzf cellranger-9.0.1.tar.gz && rm cellranger-9.0.1.tar.gz
-ENV PATH="/opt/cellranger-9.0.1:${PATH}"
+COPY cellranger-9.0.1 /opt/cellranger
+ENV PATH="/opt/cellranger:${PATH}"
 
 WORKDIR /home

--- a/images/cellranger/README.md
+++ b/images/cellranger/README.md
@@ -4,7 +4,9 @@ This folder contains a Dockerfile for the cellranger analysis.
 ## Building the image
 
 In order to build this image, the cellranger software and bcl2fastq source code components must be downloaded separately to comply with licensing, and should be placed in this folder (`images/cellranger`).
-- The current version of cellranger is `cellranger-9.0.1.tar.gz` and can be downloaded from [10X Genomics Website](https://10x.vercel.app/support/software/cell-ranger/downloads#download-links) after agreeing to their license terms.
+- The current version of cellranger is `cellranger-9.0.1.tar.xz` and can be downloaded from [10X Genomics Website](https://10x.vercel.app/support/software/cell-ranger/downloads#download-links) after agreeing to their license terms.
+  - Download the `cellranger-9.0.1.tar.xz` file and extract it using the `tar -xJf cellranger-9.0.1.tar.xz` command.
+  - The extracted directory should be named `cellranger-9.0.1` and contain the cellranger software.
 - The current version of bcl2fastq is 2.20.0 and can be downloaded from [Illumina](https://support.illumina.com/sequencing/sequencing_software/bcl2fastq-conversion-software.html) after logging into an Illumina account.
   - As we are using an Centos image, you will need to download the "Linux rpm" version of the software.
   - Note that the file Illumina provides to download is a `.zip` file that should contain the `bcl2fastq2-v2.20.0.422-Linux-x86_64.rpm` file specified in the `Dockerfile`.

--- a/images/cellranger/README.md
+++ b/images/cellranger/README.md
@@ -5,7 +5,7 @@ This folder contains a Dockerfile for the cellranger analysis.
 
 In order to build this image, the cellranger software and bcl2fastq source code components must be downloaded separately to comply with licensing, and should be placed in this folder (`images/cellranger`).
 - The current version of cellranger is `cellranger-9.0.1.tar.xz` and can be downloaded from [10X Genomics Website](https://10x.vercel.app/support/software/cell-ranger/downloads#download-links) after agreeing to their license terms.
-  - Download the `cellranger-9.0.1.tar.xz` file and extract it using the `tar -xJf cellranger-9.0.1.tar.xz` command.
+  - Download the `cellranger-9.0.1.tar.xz` file and extract it using the `tar -xf cellranger-9.0.1.tar.xz` command.
   - The extracted directory should be named `cellranger-9.0.1` and contain the cellranger software.
 - The current version of bcl2fastq is 2.20.0 and can be downloaded from [Illumina](https://support.illumina.com/sequencing/sequencing_software/bcl2fastq-conversion-software.html) after logging into an Illumina account.
   - As we are using an Centos image, you will need to download the "Linux rpm" version of the software.


### PR DESCRIPTION
Since CentOS 7 is extremely old and unsupported, I decided to see how migrating the base image for our cellranger  image would go. I chose [Alma Linux](https://almalinux.org), which seems to be the overall successor to CentOS as far as stable RPM-based images go. 

The transition seemed to go smoothly. I updated the installation instructions just a bit to do the decompression of the Cell Ranger directory outside the Dockerfile, and that (with the base change, presumably) made the image about 2 GB smaller. 

I tested that the image works, and `cellranger` runs as expected using cellranger `testrun`, which it seems to (on the server, not on an arm mac).

If this seems reasonable to you, I can push it to AWS for further testing.