### PR TITLE
Add procps to cellranger image

### DIFF
--- a/images/cellranger/Dockerfile
+++ b/images/cellranger/Dockerfile
@@ -1,6 +1,9 @@
 FROM almalinux:9
 LABEL maintainer="ccdl@alexslemonade.org"
 
+# Install dependencies to use with Nextflow
+RUN dnf install -y procps-ng && dnf clean all
+
 # Install bcl2fastq
 WORKDIR /tmp
 COPY bcl2fastq2-v2.20.0.422-Linux-x86_64.rpm bcl2fastq2.rpm


### PR DESCRIPTION
In testing using `cellranger multi` in Nextflow with the updated image added in #188, I am coming across an error that `ps` is missing when running the process. I think we want to include it in the image so that we can use things like `task.cpus` within the process that runs `cellranger multi`. Here I'm updating the image to add `procps`. 

This is the error message I'm seeing: 
```
Command exit status:
  1

Command output:
  (empty)

Command error:
  Command 'ps' required by nextflow to collect task metrics cannot be found

Work dir:
  s3://nextflow-ccdl-data/work/ec/3cab5f9d1dd2ff4dc22b3930dcf518

Container:
  589864003899.dkr.ecr.us-east-1.amazonaws.com/scpca-cellranger:9.0.1

Tip: when you have fixed the problem you can continue the execution adding the option `-resume` to the run command line
```