### PR TITLE
Add field for openscpca cell types file to scpca-meta.json

### DIFF
--- a/scripts/add-fields-scpca-meta.py
+++ b/scripts/add-fields-scpca-meta.py
@@ -8,6 +8,7 @@ This includes addition of the following missing fields in the mapping checkpoint
 - 'ref_fasta_index'
 - 'assay_ontology_term_id'
 - 'submitter_cell_types_file'
+- 'openscpca_cell_types_file'
 - 'ref_assembly'
 - 'star_index'
 - `infercnv_gene_order`
@@ -20,7 +21,7 @@ For cell type metadata changes, see `add-celltype-fields-scpca-meta.py`.
 
 To run this script for modifying the `scpca-meta.json` files from runs that have already been processed for production do:
 
-python add-fields-scpca-meta.py --checkpoints_prefix "scpca-prod/checkpoints"
+python add-fields-scpca-meta.py --checkpoints_prefix "scpca-staging/checkpoints"
 
 """
 
@@ -121,6 +122,7 @@ for run in library_df.itertuples():
         "infercnv_gene_order": "s3://scpca-references/homo_sapiens/ensembl-104/infercnv/Homo_sapiens.GRCh38.104_gene_order_arms.txt.gz",
         "assay_ontology_term_id": run.assay_ontology_term_id,
         "ref_assembly": run.sample_reference,
+        "openscpca_cell_types_file": run.openscpca_cell_types_file
     }
 
     # check if any of the new fields are already present

--- a/scripts/add-fields-scpca-meta.py
+++ b/scripts/add-fields-scpca-meta.py
@@ -19,7 +19,7 @@ If the file exists, the JSON is loaded, and the missing fields are added if they
 NOTE: This script only updates the `scpca-meta.json` files for mapping results.
 For cell type metadata changes, see `add-celltype-fields-scpca-meta.py`.
 
-To run this script for modifying the `scpca-meta.json` files from runs that have already been processed for production do:
+To run this script for modifying the `scpca-meta.json` files from runs that have already been processed and live in scpca-staging do:
 
 python add-fields-scpca-meta.py --checkpoints_prefix "scpca-staging/checkpoints"
 

--- a/scripts/add-fields-scpca-meta.py
+++ b/scripts/add-fields-scpca-meta.py
@@ -121,15 +121,15 @@ for run in library_df.itertuples():
         "star_index": "s3://scpca-references/homo_sapiens/ensembl-104/star_index/Homo_sapiens.GRCh38.104.star_idx",
         "infercnv_gene_order": "s3://scpca-references/homo_sapiens/ensembl-104/infercnv/Homo_sapiens.GRCh38.104_gene_order_arms.txt.gz",
         "assay_ontology_term_id": run.assay_ontology_term_id,
-        "ref_assembly": run.sample_reference,
-        "openscpca_cell_types_file": run.openscpca_cell_types_file
+        "ref_assembly": run.sample_reference
     }
 
     # check if any of the new fields are already present
-    # if they are all present, make sure that submitter_cell_types_file is up to date
+    # if they are all present, make sure that submitter_cell_types_file and openscpca_cell_types_file are up to date
     if (
         all(key in results_meta for key in new_fields)
-        and results_meta["submitter_cell_types_file"] == run.submitter_cell_types_file
+        and results_meta.get("submitter_cell_types_file") == run.submitter_cell_types_file
+        and results_meta.get("openscpca_cell_types_file") == run.openscpca_cell_types_file
     ):
         print(
             f"All fields are present, no updates to scpca-meta.json for {run.scpca_run_id}"
@@ -145,6 +145,13 @@ for run in library_df.itertuples():
             != run.submitter_cell_types_file
         ):
             results_meta["submitter_cell_types_file"] = run.submitter_cell_types_file
+
+        # update openscpca cell types file if it's missing or if the value doesn't match the metadata file
+        if (
+            results_meta.get("openscpca_cell_types_file")
+            != run.openscpca_cell_types_file
+        ):
+            results_meta["openscpca_cell_types_file"] = run.openscpca_cell_types_file
 
     # copy updated json file
     s3_bucket.put_object(Key=meta_json_key, Body=json.dumps(results_meta, indent=2))

--- a/scripts/add-fields-scpca-meta.py
+++ b/scripts/add-fields-scpca-meta.py
@@ -121,7 +121,7 @@ for run in library_df.itertuples():
         "star_index": "s3://scpca-references/homo_sapiens/ensembl-104/star_index/Homo_sapiens.GRCh38.104.star_idx",
         "infercnv_gene_order": "s3://scpca-references/homo_sapiens/ensembl-104/infercnv/Homo_sapiens.GRCh38.104_gene_order_arms.txt.gz",
         "assay_ontology_term_id": run.assay_ontology_term_id,
-        "ref_assembly": run.sample_reference
+        "ref_assembly": run.sample_reference,
     }
 
     # check if any of the new fields are already present


### PR DESCRIPTION
Here I'm updating the script to add fields to include `openscpca_cell_types_file` as a new field. I did the same thing that we did for updating the submitter file, where I check to make sure the value that exists (if present) matches the value in the run metadata. Otherwise it gets updated. I ran this on the `scpca/processed/checkpoints` folder and things look as expected. Once ready, I'll run this to update the checkpoints files in `scpca-staging`. 