### PR TITLE
Remove legacy AWS infrastructure

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -1,0 +1,4 @@
+# *Deprecated* AWS Nextflow batch setup
+
+This directory contains terraform files and associated setup information for creating AWS batch infrastructurte for running the scpca-nf Nextflow workflow.
+This setup is now deprecated, and the current setup is managed in https://github.com/AlexsLemonade/scpca-nf-infra

--- a/aws/nextflow-batch.tf
+++ b/aws/nextflow-batch.tf
@@ -1,56 +1,56 @@
 # AWS Batch setup
 provider "aws" {
-  region  = "us-east-1"
+  region = "us-east-1"
 }
 
 variable "default_tags" {
   description = "Default resource tags"
   type        = map(string)
-  default     = {
-    team = "science"
+  default = {
+    team    = "science"
     project = "scpca"
     purpose = "nextflow-batch"
-    config = "https://github.com/AlexsLemonade/alsf-scpca/tree/main/aws"
+    config  = "https://github.com/AlexsLemonade/alsf-scpca/tree/main/aws"
   }
 
 }
 
-resource "aws_batch_job_queue" "nf_default_queue" {
-  name     = "nextflow-batch-default-queue"
-  tags     = var.default_tags
-  state    = "ENABLED"
-  priority = 1
-  compute_environments = [
-    aws_batch_compute_environment.nf_spot.arn,
-  ]
-}
+# resource "aws_batch_job_queue" "nf_default_queue" {
+#   name     = "nextflow-batch-default-queue"
+#   tags     = var.default_tags
+#   state    = "ENABLED"
+#   priority = 1
+#   compute_environments = [
+#     aws_batch_compute_environment.nf_spot.arn,
+#   ]
+# }
 
-resource "aws_batch_job_queue" "nf_bigdisk_queue" {
-  name     = "nextflow-batch-bigdisk-queue"
-  tags     = var.default_tags
-  state    = "ENABLED"
-  priority = 1
-  compute_environments = [
-    aws_batch_compute_environment.nf_spot_bigdisk.arn,
-  ]
-}
+# resource "aws_batch_job_queue" "nf_bigdisk_queue" {
+#   name     = "nextflow-batch-bigdisk-queue"
+#   tags     = var.default_tags
+#   state    = "ENABLED"
+#   priority = 1
+#   compute_environments = [
+#     aws_batch_compute_environment.nf_spot_bigdisk.arn,
+#   ]
+# }
 
-resource "aws_batch_job_queue" "nf_autoscale_queue" {
-  name = "nextflow-batch-autoscale-queue"
-  tags = var.default_tags
-  state = "ENABLED"
-  priority = 1
-  compute_environments = [
-    aws_batch_compute_environment.nf_spot_auto_scaled_ebs.arn,
-  ]
-}
+# resource "aws_batch_job_queue" "nf_autoscale_queue" {
+#   name = "nextflow-batch-autoscale-queue"
+#   tags = var.default_tags
+#   state = "ENABLED"
+#   priority = 1
+#   compute_environments = [
+#     aws_batch_compute_environment.nf_spot_auto_scaled_ebs.arn,
+#   ]
+# }
 
 
-resource "aws_batch_job_queue" "nf_priority_queue" {
-  name     = "nextflow-batch-priority-queue"
-  state    = "ENABLED"
-  priority = 1
-  compute_environments = [
-    aws_batch_compute_environment.nf_ondemand.arn,
-  ]
-}
+# resource "aws_batch_job_queue" "nf_priority_queue" {
+#   name     = "nextflow-batch-priority-queue"
+#   state    = "ENABLED"
+#   priority = 1
+#   compute_environments = [
+#     aws_batch_compute_environment.nf_ondemand.arn,
+#   ]
+# }

--- a/aws/nextflow-compute.tf
+++ b/aws/nextflow-compute.tf
@@ -1,175 +1,175 @@
-# This file creates the compute environments used by the default and priority queues
-# The default environment is a 100 vCPU spot cluster
-# Priority environment is a 20 vCPU on demand cluster
+# # This file creates the compute environments used by the default and priority queues
+# # The default environment is a 100 vCPU spot cluster
+# # Priority environment is a 20 vCPU on demand cluster
 
-resource "aws_iam_instance_profile" "nf_ecs_instance_role" {
-  name = "nextflow-ecs-instance-role"
-  tags = var.default_tags
-  role = aws_iam_role.nf_ecs_role.name
-}
+# resource "aws_iam_instance_profile" "nf_ecs_instance_role" {
+#   name = "nextflow-ecs-instance-role"
+#   tags = var.default_tags
+#   role = aws_iam_role.nf_ecs_role.name
+# }
 
-# Create an spot instance environment with up to 256 vcpus
-# the AMI used is described in setup-log.md
-resource "aws_batch_compute_environment" "nf_spot" {
-  compute_environment_name = "nextflow-spot-compute"
-  tags = var.default_tags
-  compute_resources {
-    instance_role = aws_iam_instance_profile.nf_ecs_instance_role.arn
-    instance_type = [
-      "optimal",
-    ]
-    allocation_strategy = "SPOT_PRICE_CAPACITY_OPTIMIZED"
-    spot_iam_fleet_role = aws_iam_role.nf_spotfleet_role.arn
-    bid_percentage = 100
-    max_vcpus = 256
-    min_vcpus = 0
-    # standard launch template
-    launch_template {
-      launch_template_id = aws_launch_template.nf_lt_standard.id
-      version = aws_launch_template.nf_lt_standard.latest_version
-    }
-    # ec2_key_pair = aws_key_pair.nf_keypair.key_name
-    security_group_ids = [
-      aws_security_group.nf_security.id,
-    ]
-    subnets = [
-      aws_subnet.nf_subnet.id,
-    ]
-    type = "SPOT"
-    tags = merge(
-      var.default_tags,
-      {
-        parent = "nextflow-spot-compute"
-      }
-    )
-  }
+# # Create an spot instance environment with up to 256 vcpus
+# # the AMI used is described in setup-log.md
+# resource "aws_batch_compute_environment" "nf_spot" {
+#   compute_environment_name = "nextflow-spot-compute"
+#   tags = var.default_tags
+#   compute_resources {
+#     instance_role = aws_iam_instance_profile.nf_ecs_instance_role.arn
+#     instance_type = [
+#       "optimal",
+#     ]
+#     allocation_strategy = "SPOT_PRICE_CAPACITY_OPTIMIZED"
+#     spot_iam_fleet_role = aws_iam_role.nf_spotfleet_role.arn
+#     bid_percentage = 100
+#     max_vcpus = 256
+#     min_vcpus = 0
+#     # standard launch template
+#     launch_template {
+#       launch_template_id = aws_launch_template.nf_lt_standard.id
+#       version = aws_launch_template.nf_lt_standard.latest_version
+#     }
+#     # ec2_key_pair = aws_key_pair.nf_keypair.key_name
+#     security_group_ids = [
+#       aws_security_group.nf_security.id,
+#     ]
+#     subnets = [
+#       aws_subnet.nf_subnet.id,
+#     ]
+#     type = "SPOT"
+#     tags = merge(
+#       var.default_tags,
+#       {
+#         parent = "nextflow-spot-compute"
+#       }
+#     )
+#   }
 
-  service_role = aws_iam_role.nf_batch_role.arn
-  type         = "MANAGED"
-  depends_on   = [aws_iam_role_policy_attachment.nf_batch_role]
-}
+#   service_role = aws_iam_role.nf_batch_role.arn
+#   type         = "MANAGED"
+#   depends_on   = [aws_iam_role_policy_attachment.nf_batch_role]
+# }
 
-# Create an spot instance0 environment with up to 128 vcpus with large disks
+# # Create an spot instance0 environment with up to 128 vcpus with large disks
 
-resource "aws_batch_compute_environment" "nf_spot_bigdisk" {
-  compute_environment_name = "nextflow-spot-compute-bigdisk"
-  tags = var.default_tags
-  compute_resources {
-    instance_role = aws_iam_instance_profile.nf_ecs_instance_role.arn
-    instance_type = [
-      "optimal",
-    ]
-    allocation_strategy = "SPOT_PRICE_CAPACITY_OPTIMIZED"
-    spot_iam_fleet_role = aws_iam_role.nf_spotfleet_role.arn
-    bid_percentage = 100
-    max_vcpus = 128
-    min_vcpus = 0
-    # large disk launch template
-    launch_template {
-      launch_template_id = aws_launch_template.nf_lt_bigdisk.id
-      version = aws_launch_template.nf_lt_bigdisk.latest_version
-    }
-    # ec2_key_pair = aws_key_pair.nf_keypair.key_name
-    security_group_ids = [
-      aws_security_group.nf_security.id,
-    ]
-    subnets = [
-      aws_subnet.nf_subnet.id,
-    ]
-    type = "SPOT"
-    tags = merge(
-      var.default_tags,
-      {
-        parent = "nextflow-spot-compute"
-      }
-    )
-  }
+# resource "aws_batch_compute_environment" "nf_spot_bigdisk" {
+#   compute_environment_name = "nextflow-spot-compute-bigdisk"
+#   tags = var.default_tags
+#   compute_resources {
+#     instance_role = aws_iam_instance_profile.nf_ecs_instance_role.arn
+#     instance_type = [
+#       "optimal",
+#     ]
+#     allocation_strategy = "SPOT_PRICE_CAPACITY_OPTIMIZED"
+#     spot_iam_fleet_role = aws_iam_role.nf_spotfleet_role.arn
+#     bid_percentage = 100
+#     max_vcpus = 128
+#     min_vcpus = 0
+#     # large disk launch template
+#     launch_template {
+#       launch_template_id = aws_launch_template.nf_lt_bigdisk.id
+#       version = aws_launch_template.nf_lt_bigdisk.latest_version
+#     }
+#     # ec2_key_pair = aws_key_pair.nf_keypair.key_name
+#     security_group_ids = [
+#       aws_security_group.nf_security.id,
+#     ]
+#     subnets = [
+#       aws_subnet.nf_subnet.id,
+#     ]
+#     type = "SPOT"
+#     tags = merge(
+#       var.default_tags,
+#       {
+#         parent = "nextflow-spot-compute"
+#       }
+#     )
+#   }
 
-  service_role = aws_iam_role.nf_batch_role.arn
-  type         = "MANAGED"
-  depends_on   = [aws_iam_role_policy_attachment.nf_batch_role]
-}
+#   service_role = aws_iam_role.nf_batch_role.arn
+#   type         = "MANAGED"
+#   depends_on   = [aws_iam_role_policy_attachment.nf_batch_role]
+# }
 
-# Create a spot instance environment with up to 2048 vcpus and auto-scaled EBS.
-resource "aws_batch_compute_environment" "nf_spot_auto_scaled_ebs" {
-  compute_environment_name = "nextflow-spot-compute-auto-scaled-ebs"
-  tags = var.default_tags
-  compute_resources {
-    instance_role = aws_iam_instance_profile.nf_ecs_instance_role.arn
-    instance_type = [
-      "c4", "m4", "r4",
-      "c5", "m5", "r5",
-      "c5a", "m5a", "r5a",
-      "c6i", "m6i", "r6i",
-      "c6a", "m6a", "r6a",
-    ]
-    allocation_strategy = "SPOT_PRICE_CAPACITY_OPTIMIZED"
-    spot_iam_fleet_role = aws_iam_role.nf_spotfleet_role.arn
-    bid_percentage = 100
-    max_vcpus = 2048
-    min_vcpus = 0
+# # Create a spot instance environment with up to 2048 vcpus and auto-scaled EBS.
+# resource "aws_batch_compute_environment" "nf_spot_auto_scaled_ebs" {
+#   compute_environment_name = "nextflow-spot-compute-auto-scaled-ebs"
+#   tags = var.default_tags
+#   compute_resources {
+#     instance_role = aws_iam_instance_profile.nf_ecs_instance_role.arn
+#     instance_type = [
+#       "c4", "m4", "r4",
+#       "c5", "m5", "r5",
+#       "c5a", "m5a", "r5a",
+#       "c6i", "m6i", "r6i",
+#       "c6a", "m6a", "r6a",
+#     ]
+#     allocation_strategy = "SPOT_PRICE_CAPACITY_OPTIMIZED"
+#     spot_iam_fleet_role = aws_iam_role.nf_spotfleet_role.arn
+#     bid_percentage = 100
+#     max_vcpus = 2048
+#     min_vcpus = 0
 
-    launch_template {
-      launch_template_id = aws_launch_template.nf_lt_auto_scaled_ebs.id
-      version = aws_launch_template.nf_lt_auto_scaled_ebs.latest_version
-    }
-    security_group_ids = [
-      aws_security_group.nf_security.id,
-    ]
-    subnets = [
-      aws_subnet.nf_subnet.id,
-    ]
-    type = "SPOT"
-    tags = merge(
-      var.default_tags,
-      {
-        parent = "nextflow-spot-compute"
-      }
-    )
-  }
+#     launch_template {
+#       launch_template_id = aws_launch_template.nf_lt_auto_scaled_ebs.id
+#       version = aws_launch_template.nf_lt_auto_scaled_ebs.latest_version
+#     }
+#     security_group_ids = [
+#       aws_security_group.nf_security.id,
+#     ]
+#     subnets = [
+#       aws_subnet.nf_subnet.id,
+#     ]
+#     type = "SPOT"
+#     tags = merge(
+#       var.default_tags,
+#       {
+#         parent = "nextflow-spot-compute"
+#       }
+#     )
+#   }
 
-  service_role = aws_iam_role.nf_batch_role.arn
-  type         = "MANAGED"
-  depends_on   = [aws_iam_role_policy_attachment.nf_batch_role]
-}
+#   service_role = aws_iam_role.nf_batch_role.arn
+#   type         = "MANAGED"
+#   depends_on   = [aws_iam_role_policy_attachment.nf_batch_role]
+# }
 
-# Create an ondemand environment with up to 512 vcpus
-resource "aws_batch_compute_environment" "nf_ondemand" {
-  compute_environment_name = "nextflow-ondemand-compute"
-  tags = var.default_tags
-  compute_resources {
-    instance_role = aws_iam_instance_profile.nf_ecs_instance_role.arn
-    instance_type = [
-      "c4", "m4", "r4",
-      "c5", "m5", "r5",
-      "c5a", "m5a", "r5a",
-      "c6i", "m6i", "r6i",
-      "c6a", "m6a", "r6a",
-    ]
-    allocation_strategy = "BEST_FIT"
-    max_vcpus = 512
-    min_vcpus = 0
-    # standard launch template
-    launch_template {
-      launch_template_id = aws_launch_template.nf_lt_auto_scaled_ebs.id
-      version = aws_launch_template.nf_lt_auto_scaled_ebs.latest_version
-    }
-    # ec2_key_pair = aws_key_pair.nf_keypair.key_name
-    security_group_ids = [
-      aws_security_group.nf_security.id,
-    ]
-    subnets = [
-      aws_subnet.nf_subnet.id,
-    ]
-    type = "EC2"
-    tags = merge(
-      var.default_tags,
-      {
-        parent = "nextflow-ondemand-compute"
-      }
-    )
-  }
-  service_role = aws_iam_role.nf_batch_role.arn
-  type         = "MANAGED"
-  depends_on   = [aws_iam_role_policy_attachment.nf_batch_role]
-}
+# # Create an ondemand environment with up to 512 vcpus
+# resource "aws_batch_compute_environment" "nf_ondemand" {
+#   compute_environment_name = "nextflow-ondemand-compute"
+#   tags = var.default_tags
+#   compute_resources {
+#     instance_role = aws_iam_instance_profile.nf_ecs_instance_role.arn
+#     instance_type = [
+#       "c4", "m4", "r4",
+#       "c5", "m5", "r5",
+#       "c5a", "m5a", "r5a",
+#       "c6i", "m6i", "r6i",
+#       "c6a", "m6a", "r6a",
+#     ]
+#     allocation_strategy = "BEST_FIT"
+#     max_vcpus = 512
+#     min_vcpus = 0
+#     # standard launch template
+#     launch_template {
+#       launch_template_id = aws_launch_template.nf_lt_auto_scaled_ebs.id
+#       version = aws_launch_template.nf_lt_auto_scaled_ebs.latest_version
+#     }
+#     # ec2_key_pair = aws_key_pair.nf_keypair.key_name
+#     security_group_ids = [
+#       aws_security_group.nf_security.id,
+#     ]
+#     subnets = [
+#       aws_subnet.nf_subnet.id,
+#     ]
+#     type = "EC2"
+#     tags = merge(
+#       var.default_tags,
+#       {
+#         parent = "nextflow-ondemand-compute"
+#       }
+#     )
+#   }
+#   service_role = aws_iam_role.nf_batch_role.arn
+#   type         = "MANAGED"
+#   depends_on   = [aws_iam_role_policy_attachment.nf_batch_role]
+# }

--- a/aws/nextflow-groups.tf
+++ b/aws/nextflow-groups.tf
@@ -1,28 +1,28 @@
-# This file sets the access settings for the nextflow-batch group
-# Currently includes read acess to all s3, and write access to select buckets
+# # This file sets the access settings for the nextflow-batch group
+# # Currently includes read acess to all s3, and write access to select buckets
 
-resource "aws_iam_group" "nf_group" {
-  name = "nextflow-batch"
-}
-
-# Batch access
-resource "aws_iam_group_policy_attachment" "batch_access" {
-  group = aws_iam_group.nf_group.name
-  policy_arn = "arn:aws:iam::aws:policy/AWSBatchFullAccess"
-}
-
-# EC2 access (may not be needed?)
-# resource "aws_iam_group_policy_attachment" "ec2_access" {
-#   group      = aws_iam_group.nf_group.name
-#   policy_arn = "arn:aws:iam::aws:policy/AmazonEC2FullAccess"
+# resource "aws_iam_group" "nf_group" {
+#   name = "nextflow-batch"
 # }
 
-resource "aws_iam_group_policy_attachment" "read_s3" {
-  group = aws_iam_group.nf_group.name
-  policy_arn = aws_iam_policy.nf_read_S3.arn
-}
+# # Batch access
+# resource "aws_iam_group_policy_attachment" "batch_access" {
+#   group = aws_iam_group.nf_group.name
+#   policy_arn = "arn:aws:iam::aws:policy/AWSBatchFullAccess"
+# }
 
-resource "aws_iam_group_policy_attachment" "rw_s3" {
-  group = aws_iam_group.nf_group.name
-  policy_arn = aws_iam_policy.nf_readwrite_S3.arn
-}
+# # EC2 access (may not be needed?)
+# # resource "aws_iam_group_policy_attachment" "ec2_access" {
+# #   group      = aws_iam_group.nf_group.name
+# #   policy_arn = "arn:aws:iam::aws:policy/AmazonEC2FullAccess"
+# # }
+
+# resource "aws_iam_group_policy_attachment" "read_s3" {
+#   group = aws_iam_group.nf_group.name
+#   policy_arn = aws_iam_policy.nf_read_S3.arn
+# }
+
+# resource "aws_iam_group_policy_attachment" "rw_s3" {
+#   group = aws_iam_group.nf_group.name
+#   policy_arn = aws_iam_policy.nf_readwrite_S3.arn
+# }

--- a/aws/nextflow-launch-templates.tf
+++ b/aws/nextflow-launch-templates.tf
@@ -1,48 +1,48 @@
-resource "aws_launch_template" "nf_lt_standard" {
-  name = "nextflow-launchtemplate-standard"
-  tags = var.default_tags
-  # ccdl-nextflow-base-v2.0 image
-  image_id = "ami-01c08d4de548477df"
-  block_device_mappings {
-    device_name = "/dev/xvda"
-    ebs {
-      volume_size = 128
-      encrypted = true
-      delete_on_termination = true
-    }
-  }
-  update_default_version = true
-}
+# resource "aws_launch_template" "nf_lt_standard" {
+#   name = "nextflow-launchtemplate-standard"
+#   tags = var.default_tags
+#   # ccdl-nextflow-base-v2.0 image
+#   image_id = "ami-01c08d4de548477df"
+#   block_device_mappings {
+#     device_name = "/dev/xvda"
+#     ebs {
+#       volume_size = 128
+#       encrypted = true
+#       delete_on_termination = true
+#     }
+#   }
+#   update_default_version = true
+# }
 
-resource "aws_launch_template" "nf_lt_bigdisk" {
-  name = "nextflow-launchtemplate-bigdisk"
-  tags = var.default_tags
-  # ccdl-nextflow-base-v2.0 image
-  image_id = "ami-01c08d4de548477df"
-  block_device_mappings {
-    device_name = "/dev/xvda"
-    ebs {
-      volume_size = 1000
-      encrypted = true
-      delete_on_termination = true
-    }
-  }
-  update_default_version = true
-}
+# resource "aws_launch_template" "nf_lt_bigdisk" {
+#   name = "nextflow-launchtemplate-bigdisk"
+#   tags = var.default_tags
+#   # ccdl-nextflow-base-v2.0 image
+#   image_id = "ami-01c08d4de548477df"
+#   block_device_mappings {
+#     device_name = "/dev/xvda"
+#     ebs {
+#       volume_size = 1000
+#       encrypted = true
+#       delete_on_termination = true
+#     }
+#   }
+#   update_default_version = true
+# }
 
-resource "aws_launch_template" "nf_lt_auto_scaled_ebs" {
-  name = "nextflow-launchtemplate-auto-scaled-ebs"
-  tags = var.default_tags
-  image_id = "ami-01c08d4de548477df"  # ccdl-nextflow-base-v2.0 image
-  block_device_mappings {
-    device_name = "/dev/xvda"
-    ebs {
-      volume_size = 30  # GiB
-      volume_type = "gp3"
-      encrypted = true
-      delete_on_termination = true
-    }
-  }
-  update_default_version = true
-  user_data = filebase64("./user_data/auto_scaled_ebs")
-}
+# resource "aws_launch_template" "nf_lt_auto_scaled_ebs" {
+#   name = "nextflow-launchtemplate-auto-scaled-ebs"
+#   tags = var.default_tags
+#   image_id = "ami-01c08d4de548477df"  # ccdl-nextflow-base-v2.0 image
+#   block_device_mappings {
+#     device_name = "/dev/xvda"
+#     ebs {
+#       volume_size = 30  # GiB
+#       volume_type = "gp3"
+#       encrypted = true
+#       delete_on_termination = true
+#     }
+#   }
+#   update_default_version = true
+#   user_data = filebase64("./user_data/auto_scaled_ebs")
+# }

--- a/aws/nextflow-policies.tf
+++ b/aws/nextflow-policies.tf
@@ -1,220 +1,220 @@
-# Specific policies used by roles and groups
-# Which S3 buckets are available for reading
+# # Specific policies used by roles and groups
+# # Which S3 buckets are available for reading
 
-# S3 Group policies taken from AWS Nextflow batch setup
+# # S3 Group policies taken from AWS Nextflow batch setup
 
-# This policy allows read and write access to specific buckets for nextflow processing
-resource "aws_iam_policy" "nf_readwrite_S3" {
-  name   = "nextflow-ccdl-readwrite-s3"
-  tags   = var.default_tags
-  policy = <<EOF
-{
- "Version": "2012-10-17",
- "Statement": [
-  {
-   "Effect": "Allow",
-   "Action": [
-    "s3:PutAnalyticsConfiguration",
-    "s3:GetObjectVersionTagging",
-    "s3:ReplicateObject",
-    "s3:GetObjectAcl",
-    "s3:GetBucketObjectLockConfiguration",
-    "s3:PutLifecycleConfiguration",
-    "s3:GetObjectVersionAcl",
-    "s3:PutObjectTagging",
-    "s3:DeleteObject",
-    "s3:DeleteObjectTagging",
-    "s3:GetBucketPolicyStatus",
-    "s3:GetObjectRetention",
-    "s3:GetBucketWebsite",
-    "s3:PutReplicationConfiguration",
-    "s3:DeleteObjectVersionTagging",
-    "s3:PutObjectLegalHold",
-    "s3:GetObjectLegalHold",
-    "s3:GetBucketNotification",
-    "s3:PutBucketCORS",
-    "s3:GetReplicationConfiguration",
-    "s3:ListMultipartUploadParts",
-    "s3:PutObject",
-    "s3:GetObject",
-    "s3:PutBucketNotification",
-    "s3:PutBucketLogging",
-    "s3:GetAnalyticsConfiguration",
-    "s3:PutBucketObjectLockConfiguration",
-    "s3:GetObjectVersionForReplication",
-    "s3:GetLifecycleConfiguration",
-    "s3:GetInventoryConfiguration",
-    "s3:GetBucketTagging",
-    "s3:PutAccelerateConfiguration",
-    "s3:DeleteObjectVersion",
-    "s3:GetBucketLogging",
-    "s3:ListBucketVersions",
-    "s3:ReplicateTags",
-    "s3:RestoreObject",
-    "s3:ListBucket",
-    "s3:GetAccelerateConfiguration",
-    "s3:GetBucketPolicy",
-    "s3:PutEncryptionConfiguration",
-    "s3:GetEncryptionConfiguration",
-    "s3:GetObjectVersionTorrent",
-    "s3:AbortMultipartUpload",
-    "s3:PutBucketTagging",
-    "s3:GetBucketRequestPayment",
-    "s3:GetObjectTagging",
-    "s3:GetMetricsConfiguration",
-    "s3:PutBucketVersioning",
-    "s3:GetBucketPublicAccessBlock",
-    "s3:ListBucketMultipartUploads",
-    "s3:PutMetricsConfiguration",
-    "s3:PutObjectVersionTagging",
-    "s3:GetBucketVersioning",
-    "s3:GetBucketAcl",
-    "s3:PutInventoryConfiguration",
-    "s3:GetObjectTorrent",
-    "s3:PutBucketWebsite",
-    "s3:PutBucketRequestPayment",
-    "s3:PutObjectRetention",
-    "s3:GetBucketCORS",
-    "s3:GetBucketLocation",
-    "s3:ReplicateDelete",
-    "s3:GetObjectVersion"
-   ],
-   "Resource": [
-    "arn:aws:s3:::nextflow-ccdl-data/*",
-    "arn:aws:s3:::nextflow-ccdl-results/*",
-    "arn:aws:s3:::nextflow-ccdl-data",
-    "arn:aws:s3:::nextflow-ccdl-results",
-    "arn:aws:s3:::openscpca-temp-simdata",
-    "arn:aws:s3:::openscpca-temp-simdata/*"
+# # This policy allows read and write access to specific buckets for nextflow processing
+# resource "aws_iam_policy" "nf_readwrite_S3" {
+#   name   = "nextflow-ccdl-readwrite-s3"
+#   tags   = var.default_tags
+#   policy = <<EOF
+# {
+#  "Version": "2012-10-17",
+#  "Statement": [
+#   {
+#    "Effect": "Allow",
+#    "Action": [
+#     "s3:PutAnalyticsConfiguration",
+#     "s3:GetObjectVersionTagging",
+#     "s3:ReplicateObject",
+#     "s3:GetObjectAcl",
+#     "s3:GetBucketObjectLockConfiguration",
+#     "s3:PutLifecycleConfiguration",
+#     "s3:GetObjectVersionAcl",
+#     "s3:PutObjectTagging",
+#     "s3:DeleteObject",
+#     "s3:DeleteObjectTagging",
+#     "s3:GetBucketPolicyStatus",
+#     "s3:GetObjectRetention",
+#     "s3:GetBucketWebsite",
+#     "s3:PutReplicationConfiguration",
+#     "s3:DeleteObjectVersionTagging",
+#     "s3:PutObjectLegalHold",
+#     "s3:GetObjectLegalHold",
+#     "s3:GetBucketNotification",
+#     "s3:PutBucketCORS",
+#     "s3:GetReplicationConfiguration",
+#     "s3:ListMultipartUploadParts",
+#     "s3:PutObject",
+#     "s3:GetObject",
+#     "s3:PutBucketNotification",
+#     "s3:PutBucketLogging",
+#     "s3:GetAnalyticsConfiguration",
+#     "s3:PutBucketObjectLockConfiguration",
+#     "s3:GetObjectVersionForReplication",
+#     "s3:GetLifecycleConfiguration",
+#     "s3:GetInventoryConfiguration",
+#     "s3:GetBucketTagging",
+#     "s3:PutAccelerateConfiguration",
+#     "s3:DeleteObjectVersion",
+#     "s3:GetBucketLogging",
+#     "s3:ListBucketVersions",
+#     "s3:ReplicateTags",
+#     "s3:RestoreObject",
+#     "s3:ListBucket",
+#     "s3:GetAccelerateConfiguration",
+#     "s3:GetBucketPolicy",
+#     "s3:PutEncryptionConfiguration",
+#     "s3:GetEncryptionConfiguration",
+#     "s3:GetObjectVersionTorrent",
+#     "s3:AbortMultipartUpload",
+#     "s3:PutBucketTagging",
+#     "s3:GetBucketRequestPayment",
+#     "s3:GetObjectTagging",
+#     "s3:GetMetricsConfiguration",
+#     "s3:PutBucketVersioning",
+#     "s3:GetBucketPublicAccessBlock",
+#     "s3:ListBucketMultipartUploads",
+#     "s3:PutMetricsConfiguration",
+#     "s3:PutObjectVersionTagging",
+#     "s3:GetBucketVersioning",
+#     "s3:GetBucketAcl",
+#     "s3:PutInventoryConfiguration",
+#     "s3:GetObjectTorrent",
+#     "s3:PutBucketWebsite",
+#     "s3:PutBucketRequestPayment",
+#     "s3:PutObjectRetention",
+#     "s3:GetBucketCORS",
+#     "s3:GetBucketLocation",
+#     "s3:ReplicateDelete",
+#     "s3:GetObjectVersion"
+#    ],
+#    "Resource": [
+#     "arn:aws:s3:::nextflow-ccdl-data/*",
+#     "arn:aws:s3:::nextflow-ccdl-results/*",
+#     "arn:aws:s3:::nextflow-ccdl-data",
+#     "arn:aws:s3:::nextflow-ccdl-results",
+#     "arn:aws:s3:::openscpca-temp-simdata",
+#     "arn:aws:s3:::openscpca-temp-simdata/*"
 
-   ]
-  },
-  {
-   "Effect": "Allow",
-   "Action": [
-    "s3:GetAccountPublicAccessBlock",
-    "s3:ListAllMyBuckets",
-    "s3:ListAccessPoints",
-    "s3:HeadBucket"
-   ],
-   "Resource": "*"
-  }
- ]
-}
-EOF
-}
+#    ]
+#   },
+#   {
+#    "Effect": "Allow",
+#    "Action": [
+#     "s3:GetAccountPublicAccessBlock",
+#     "s3:ListAllMyBuckets",
+#     "s3:ListAccessPoints",
+#     "s3:HeadBucket"
+#    ],
+#    "Resource": "*"
+#   }
+#  ]
+# }
+# EOF
+# }
 
-# This policy gives read access to all S3 buckets
-resource "aws_iam_policy" "nf_read_S3" {
-  name   = "nextflow-ccdl-read-s3"
-  tags   = var.default_tags
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "s3:GetObjectVersionTorrent",
-        "s3:GetObjectAcl",
-        "s3:GetObject",
-        "s3:GetObjectTorrent",
-        "s3:GetObjectRetention",
-        "s3:GetObjectVersionTagging",
-        "s3:GetObjectVersionAcl",
-        "s3:GetObjectTagging",
-        "s3:GetObjectVersionForReplication",
-        "s3:GetObjectLegalHold",
-        "s3:GetObjectVersion",
-        "s3:ListMultipartUploadParts"
-      ],
-      "Resource": [
-        "arn:aws:s3:::ccdl-scpca-data/*",
-        "arn:aws:s3:::nextflow-ccdl-data/*",
-        "arn:aws:s3:::nextflow-ccdl-results/*",
-        "arn:aws:s3:::openscpca-celltype-annotations-public-access/*"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "s3:GetLifecycleConfiguration",
-        "s3:GetBucketTagging",
-        "s3:GetInventoryConfiguration",
-        "s3:ListBucketVersions",
-        "s3:GetBucketLogging",
-        "s3:ListBucket",
-        "s3:GetAccelerateConfiguration",
-        "s3:GetBucketPolicy",
-        "s3:GetEncryptionConfiguration",
-        "s3:GetBucketObjectLockConfiguration",
-        "s3:GetBucketRequestPayment",
-        "s3:GetAccessPointPolicyStatus",
-        "s3:GetMetricsConfiguration",
-        "s3:GetBucketPublicAccessBlock",
-        "s3:GetBucketPolicyStatus",
-        "s3:ListBucketMultipartUploads",
-        "s3:GetBucketWebsite",
-        "s3:GetBucketVersioning",
-        "s3:GetBucketAcl",
-        "s3:GetBucketNotification",
-        "s3:GetReplicationConfiguration",
-        "s3:DescribeJob",
-        "s3:GetBucketCORS",
-        "s3:GetAnalyticsConfiguration",
-        "s3:GetBucketLocation",
-        "s3:GetAccessPointPolicy"
-      ],
-      "Resource": [
-        "arn:aws:s3:::ccdl-scpca-data",
-        "arn:aws:s3:::nextflow-ccdl-data",
-        "arn:aws:s3:::nextflow-ccdl-results",
-        "arn:aws:s3:::openscpca-celltype-annotations-public-access",
-        "arn:aws:s3:*:*:accesspoint/*",
-        "arn:aws:s3:*:*:job/*"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "s3:GetAccessPoint",
-        "s3:GetAccountPublicAccessBlock",
-        "s3:ListAllMyBuckets",
-        "s3:ListAccessPoints",
-        "s3:ListJobs",
-        "s3:HeadBucket"
-      ],
-      "Resource": "*"
-    }
-  ]
-}
-EOF
-}
+# # This policy gives read access to all S3 buckets
+# resource "aws_iam_policy" "nf_read_S3" {
+#   name   = "nextflow-ccdl-read-s3"
+#   tags   = var.default_tags
+#   policy = <<EOF
+# {
+#   "Version": "2012-10-17",
+#   "Statement": [
+#     {
+#       "Effect": "Allow",
+#       "Action": [
+#         "s3:GetObjectVersionTorrent",
+#         "s3:GetObjectAcl",
+#         "s3:GetObject",
+#         "s3:GetObjectTorrent",
+#         "s3:GetObjectRetention",
+#         "s3:GetObjectVersionTagging",
+#         "s3:GetObjectVersionAcl",
+#         "s3:GetObjectTagging",
+#         "s3:GetObjectVersionForReplication",
+#         "s3:GetObjectLegalHold",
+#         "s3:GetObjectVersion",
+#         "s3:ListMultipartUploadParts"
+#       ],
+#       "Resource": [
+#         "arn:aws:s3:::ccdl-scpca-data/*",
+#         "arn:aws:s3:::nextflow-ccdl-data/*",
+#         "arn:aws:s3:::nextflow-ccdl-results/*",
+#         "arn:aws:s3:::openscpca-celltype-annotations-public-access/*"
+#       ]
+#     },
+#     {
+#       "Effect": "Allow",
+#       "Action": [
+#         "s3:GetLifecycleConfiguration",
+#         "s3:GetBucketTagging",
+#         "s3:GetInventoryConfiguration",
+#         "s3:ListBucketVersions",
+#         "s3:GetBucketLogging",
+#         "s3:ListBucket",
+#         "s3:GetAccelerateConfiguration",
+#         "s3:GetBucketPolicy",
+#         "s3:GetEncryptionConfiguration",
+#         "s3:GetBucketObjectLockConfiguration",
+#         "s3:GetBucketRequestPayment",
+#         "s3:GetAccessPointPolicyStatus",
+#         "s3:GetMetricsConfiguration",
+#         "s3:GetBucketPublicAccessBlock",
+#         "s3:GetBucketPolicyStatus",
+#         "s3:ListBucketMultipartUploads",
+#         "s3:GetBucketWebsite",
+#         "s3:GetBucketVersioning",
+#         "s3:GetBucketAcl",
+#         "s3:GetBucketNotification",
+#         "s3:GetReplicationConfiguration",
+#         "s3:DescribeJob",
+#         "s3:GetBucketCORS",
+#         "s3:GetAnalyticsConfiguration",
+#         "s3:GetBucketLocation",
+#         "s3:GetAccessPointPolicy"
+#       ],
+#       "Resource": [
+#         "arn:aws:s3:::ccdl-scpca-data",
+#         "arn:aws:s3:::nextflow-ccdl-data",
+#         "arn:aws:s3:::nextflow-ccdl-results",
+#         "arn:aws:s3:::openscpca-celltype-annotations-public-access",
+#         "arn:aws:s3:*:*:accesspoint/*",
+#         "arn:aws:s3:*:*:job/*"
+#       ]
+#     },
+#     {
+#       "Effect": "Allow",
+#       "Action": [
+#         "s3:GetAccessPoint",
+#         "s3:GetAccountPublicAccessBlock",
+#         "s3:ListAllMyBuckets",
+#         "s3:ListAccessPoints",
+#         "s3:ListJobs",
+#         "s3:HeadBucket"
+#       ],
+#       "Resource": "*"
+#     }
+#   ]
+# }
+# EOF
+# }
 
-resource "aws_iam_policy" "nf_manage_ebs" {
-  name        = "nextflow-ccdl-manage-ebs"
-  description = "A policy that allows to manage (attach/create/delete) EBS volumes."
-  tags        = var.default_tags
-  policy      = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ec2:AttachVolume",
-                "ec2:DescribeVolumeStatus",
-                "ec2:DescribeVolumes",
-                "ec2:DescribeTags",
-                "ec2:ModifyInstanceAttribute",
-                "ec2:DescribeVolumeAttribute",
-                "ec2:CreateVolume",
-                "ec2:DeleteVolume",
-                "ec2:CreateTags"
-            ],
-            "Resource": "*"
-        }
-    ]
-}
-EOF
-}
+# resource "aws_iam_policy" "nf_manage_ebs" {
+#   name        = "nextflow-ccdl-manage-ebs"
+#   description = "A policy that allows to manage (attach/create/delete) EBS volumes."
+#   tags        = var.default_tags
+#   policy      = <<EOF
+# {
+#     "Version": "2012-10-17",
+#     "Statement": [
+#         {
+#             "Effect": "Allow",
+#             "Action": [
+#                 "ec2:AttachVolume",
+#                 "ec2:DescribeVolumeStatus",
+#                 "ec2:DescribeVolumes",
+#                 "ec2:DescribeTags",
+#                 "ec2:ModifyInstanceAttribute",
+#                 "ec2:DescribeVolumeAttribute",
+#                 "ec2:CreateVolume",
+#                 "ec2:DeleteVolume",
+#                 "ec2:CreateTags"
+#             ],
+#             "Resource": "*"
+#         }
+#     ]
+# }
+# EOF
+# }

--- a/aws/nextflow-roles.tf
+++ b/aws/nextflow-roles.tf
@@ -1,100 +1,100 @@
-# This sets specific roles for access to AWS services
-# used by compute environments and batch queues
+# # This sets specific roles for access to AWS services
+# # used by compute environments and batch queues
 
 
-### Batch Role
-resource "aws_iam_role" "nf_batch_role" {
-  name = "nextflow-batch-service-role"
-  tags = var.default_tags
-  assume_role_policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-    {
-        "Action": "sts:AssumeRole",
-        "Effect": "Allow",
-        "Principal": {
-        "Service": "batch.amazonaws.com"
-        }
-    }
-    ]
-}
-EOF
-}
+# ### Batch Role
+# resource "aws_iam_role" "nf_batch_role" {
+#   name = "nextflow-batch-service-role"
+#   tags = var.default_tags
+#   assume_role_policy = <<EOF
+# {
+#     "Version": "2012-10-17",
+#     "Statement": [
+#     {
+#         "Action": "sts:AssumeRole",
+#         "Effect": "Allow",
+#         "Principal": {
+#         "Service": "batch.amazonaws.com"
+#         }
+#     }
+#     ]
+# }
+# EOF
+# }
 
-resource "aws_iam_role_policy_attachment" "nf_batch_role" {
-  role = aws_iam_role.nf_batch_role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole"
-}
+# resource "aws_iam_role_policy_attachment" "nf_batch_role" {
+#   role = aws_iam_role.nf_batch_role.name
+#   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole"
+# }
 
 
-### ECS Role
-resource "aws_iam_role" "nf_ecs_role" {
-  name = "nextflow-ecs-instance-role"
-  tags = var.default_tags
-  assume_role_policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-    {
-        "Action": "sts:AssumeRole",
-        "Effect": "Allow",
-        "Principal": {
-        "Service": "ec2.amazonaws.com"
-        }
-    }
-    ]
-}
-EOF
-}
+# ### ECS Role
+# resource "aws_iam_role" "nf_ecs_role" {
+#   name = "nextflow-ecs-instance-role"
+#   tags = var.default_tags
+#   assume_role_policy = <<EOF
+# {
+#     "Version": "2012-10-17",
+#     "Statement": [
+#     {
+#         "Action": "sts:AssumeRole",
+#         "Effect": "Allow",
+#         "Principal": {
+#         "Service": "ec2.amazonaws.com"
+#         }
+#     }
+#     ]
+# }
+# EOF
+# }
 
-resource "aws_iam_role_policy_attachment" "ecs_ec2_container" {
-  role = aws_iam_role.nf_ecs_role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
-}
+# resource "aws_iam_role_policy_attachment" "ecs_ec2_container" {
+#   role = aws_iam_role.nf_ecs_role.name
+#   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+# }
 
-resource "aws_iam_role_policy_attachment" "ecs_rw_s3" {
-  role = aws_iam_role.nf_ecs_role.name
-  policy_arn = aws_iam_policy.nf_readwrite_S3.arn
-}
+# resource "aws_iam_role_policy_attachment" "ecs_rw_s3" {
+#   role = aws_iam_role.nf_ecs_role.name
+#   policy_arn = aws_iam_policy.nf_readwrite_S3.arn
+# }
 
-resource "aws_iam_role_policy_attachment" "ecs_read_s3" {
-  role = aws_iam_role.nf_ecs_role.name
-  policy_arn = aws_iam_policy.nf_read_S3.arn
-}
+# resource "aws_iam_role_policy_attachment" "ecs_read_s3" {
+#   role = aws_iam_role.nf_ecs_role.name
+#   policy_arn = aws_iam_policy.nf_read_S3.arn
+# }
 
-resource "aws_iam_role_policy_attachment" "ecs_auto_scale_ebs" {
-  role = aws_iam_role.nf_ecs_role.name
-  policy_arn = aws_iam_policy.nf_manage_ebs.arn
-}
+# resource "aws_iam_role_policy_attachment" "ecs_auto_scale_ebs" {
+#   role = aws_iam_role.nf_ecs_role.name
+#   policy_arn = aws_iam_policy.nf_manage_ebs.arn
+# }
 
-### Spotfleet Role
-resource "aws_iam_role" "nf_spotfleet_role" {
-  name = "nextflow-spotfleet-role"
-  assume_role_policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-    {
-        "Action": "sts:AssumeRole",
-        "Effect": "Allow",
-        "Principal": {
-        "Service": "spotfleet.amazonaws.com"
-        }
-    }
-    ]
-}
-EOF
-  tags = var.default_tags
-}
+# ### Spotfleet Role
+# resource "aws_iam_role" "nf_spotfleet_role" {
+#   name = "nextflow-spotfleet-role"
+#   assume_role_policy = <<EOF
+# {
+#     "Version": "2012-10-17",
+#     "Statement": [
+#     {
+#         "Action": "sts:AssumeRole",
+#         "Effect": "Allow",
+#         "Principal": {
+#         "Service": "spotfleet.amazonaws.com"
+#         }
+#     }
+#     ]
+# }
+# EOF
+#   tags = var.default_tags
+# }
 
-resource "aws_iam_role_policy_attachment" "nf_spotfleet_tagging" {
-  role = aws_iam_role.nf_spotfleet_role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole"
-}
+# resource "aws_iam_role_policy_attachment" "nf_spotfleet_tagging" {
+#   role = aws_iam_role.nf_spotfleet_role.name
+#   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole"
+# }
 
-resource "aws_iam_role_policy_attachment" "nf_spotfleet_autoscale" {
-  role = aws_iam_role.nf_spotfleet_role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetAutoscaleRole"
-}
+# resource "aws_iam_role_policy_attachment" "nf_spotfleet_autoscale" {
+#   role = aws_iam_role.nf_spotfleet_role.name
+#   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetAutoscaleRole"
+# }
 

--- a/aws/nextflow-security.tf
+++ b/aws/nextflow-security.tf
@@ -1,83 +1,83 @@
-# VPC and network security settings
+# # VPC and network security settings
 
-resource "aws_security_group" "nf_security" {
-  name = "nextflow-security-group"
-  vpc_id = aws_vpc.nf_vpc.id
-  tags = var.default_tags
+# resource "aws_security_group" "nf_security" {
+#   name = "nextflow-security-group"
+#   vpc_id = aws_vpc.nf_vpc.id
+#   tags = var.default_tags
 
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+#   egress {
+#     from_port   = 0
+#     to_port     = 0
+#     protocol    = "-1"
+#     cidr_blocks = ["0.0.0.0/0"]
+#   }
 
-  # ingress {
-  #   description = "SSH from anywhere."
-  #   from_port   = 22
-  #   to_port     = 22
-  #   protocol    = "tcp"
-  #   cidr_blocks = ["0.0.0.0/0"]
-  # }
-}
-
-# resource "aws_key_pair" "nf_keypair" {
-#   key_name = "nextflow-key"
-#   public_key = "PUT_YOUR_PUBLIC_KEY_HERE"
+#   # ingress {
+#   #   description = "SSH from anywhere."
+#   #   from_port   = 22
+#   #   to_port     = 22
+#   #   protocol    = "tcp"
+#   #   cidr_blocks = ["0.0.0.0/0"]
+#   # }
 # }
 
-resource "aws_vpc" "nf_vpc" {
-  cidr_block = "10.1.0.0/16"
-  tags = merge(
-    {
-      Name = "nextflow-vpc"
-    },
-    var.default_tags
-  )
-  enable_dns_hostnames = true
-}
+# # resource "aws_key_pair" "nf_keypair" {
+# #   key_name = "nextflow-key"
+# #   public_key = "PUT_YOUR_PUBLIC_KEY_HERE"
+# # }
 
-resource "aws_internet_gateway" "nf_gateway" {
-  vpc_id = aws_vpc.nf_vpc.id
+# resource "aws_vpc" "nf_vpc" {
+#   cidr_block = "10.1.0.0/16"
+#   tags = merge(
+#     {
+#       Name = "nextflow-vpc"
+#     },
+#     var.default_tags
+#   )
+#   enable_dns_hostnames = true
+# }
 
-  tags = merge(
-    {
-      Name = "nextflow-gateway"
-    },
-    var.default_tags
-  )
+# resource "aws_internet_gateway" "nf_gateway" {
+#   vpc_id = aws_vpc.nf_vpc.id
 
-}
+#   tags = merge(
+#     {
+#       Name = "nextflow-gateway"
+#     },
+#     var.default_tags
+#   )
 
-resource "aws_subnet" "nf_subnet" {
-  vpc_id = aws_vpc.nf_vpc.id
-  cidr_block = "10.1.1.0/24"
-  tags = merge(
-    {
-      Name = "nextflow-subnet"
-    },
-    var.default_tags
-  )
-  map_public_ip_on_launch = true
-}
+# }
 
-resource "aws_route_table" "nf_route_table" {
-  vpc_id = aws_vpc.nf_vpc.id
+# resource "aws_subnet" "nf_subnet" {
+#   vpc_id = aws_vpc.nf_vpc.id
+#   cidr_block = "10.1.1.0/24"
+#   tags = merge(
+#     {
+#       Name = "nextflow-subnet"
+#     },
+#     var.default_tags
+#   )
+#   map_public_ip_on_launch = true
+# }
 
-  route {
-    cidr_block = "0.0.0.0/0"
-    gateway_id = aws_internet_gateway.nf_gateway.id
-  }
+# resource "aws_route_table" "nf_route_table" {
+#   vpc_id = aws_vpc.nf_vpc.id
 
-  tags = merge(
-    {
-      Name = "nextflow-route-table"
-    },
-    var.default_tags
-  )
-}
+#   route {
+#     cidr_block = "0.0.0.0/0"
+#     gateway_id = aws_internet_gateway.nf_gateway.id
+#   }
 
-resource "aws_route_table_association" "nf_route_table_association" {
-  subnet_id = aws_subnet.nf_subnet.id
-  route_table_id = aws_route_table.nf_route_table.id
-}
+#   tags = merge(
+#     {
+#       Name = "nextflow-route-table"
+#     },
+#     var.default_tags
+#   )
+# }
+
+# resource "aws_route_table_association" "nf_route_table_association" {
+#   subnet_id = aws_subnet.nf_subnet.id
+#   route_table_id = aws_route_table.nf_route_table.id
+# }


### PR DESCRIPTION
Closes https://github.com/AlexsLemonade/ScPCA-admin/issues/1446

Rather than fully deleting these files, I left them with all of the resources commented out, just in case we want to refer back to how we were doing things like the auto-expanding drives. While we could of course extract them from git history, that seems like it would be harder.

I have not yet fully applied this, though I did delete some elements already... I will apply it before merging.

I already removed the relevant AMI, which was probably just a bit premature.